### PR TITLE
[106] As an iOS developer, I can see the structure of project after create it from iOS template

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/Nimble Templates/App.xctemplate/TemplateInfo.plist
+++ b/Nimble Templates/App.xctemplate/TemplateInfo.plist
@@ -9,7 +9,6 @@
     <key>Ancestors</key>
     <array>
         <string>com.apple.dt.unit.coreDataCocoaTouchApplication</string>
-        <string>com.apple.dt.unit.sceneLifecycleApplication</string>
     </array>
     <key>Concrete</key>
     <true/>
@@ -186,5 +185,30 @@ let contentView = ContentView().environment(\.managedObjectContext, context)
             <string>popup</string>
         </dict>
     </array>
+
+    <key>Components</key>
+    <array>
+        <dict>
+            <key>Identifier</key>
+            <string>co.nimble.ios-template.blank</string>
+            <key>Name</key>
+            <string>Design</string>
+        </dict>
+
+        <dict>
+            <key>Identifier</key>
+            <string>co.nimble.ios-template.sources</string>
+            <key>Name</key>
+            <string>Sources</string>
+        </dict>
+
+        <dict>
+            <key>Identifier</key>
+            <string>co.nimble.ios-template.tests</string>
+            <key>Name</key>
+            <string>Tests</string>
+        </dict>
+    </array>
+
 </dict>
 </plist>

--- a/Nimble Templates/App.xctemplate/TemplateInfo.plist
+++ b/Nimble Templates/App.xctemplate/TemplateInfo.plist
@@ -190,13 +190,6 @@ let contentView = ContentView().environment(\.managedObjectContext, context)
     <array>
         <dict>
             <key>Identifier</key>
-            <string>co.nimble.ios-template.blank</string>
-            <key>Name</key>
-            <string>Design</string>
-        </dict>
-
-        <dict>
-            <key>Identifier</key>
             <string>co.nimble.ios-template.sources</string>
             <key>Name</key>
             <string>Sources</string>

--- a/Nimble Templates/iOS Blank.xctemplate/TemplateInfo.plist
+++ b/Nimble Templates/iOS Blank.xctemplate/TemplateInfo.plist
@@ -8,7 +8,17 @@
     <string>co.nimble.ios-template.blank</string>
     <key>Nodes</key>
     <array>
-        <string>.temp</string>
+        <string>temp</string>
     </array>
+    
+    <key>Definitions</key>
+    <dict>
+        <key>temp</key>
+        <dict>
+			<key>Path</key>
+			<string>../temp/</string>
+        </dict>
+    </dict>
+
 </dict>
 </plist>

--- a/Nimble Templates/iOS Blank.xctemplate/TemplateInfo.plist
+++ b/Nimble Templates/iOS Blank.xctemplate/TemplateInfo.plist
@@ -15,8 +15,8 @@
     <dict>
         <key>temp</key>
         <dict>
-			<key>Path</key>
-			<string>../temp/</string>
+            <key>Path</key>
+            <string>../temp/</string>
         </dict>
     </dict>
 

--- a/Nimble Templates/iOS Blank.xctemplate/TemplateInfo.plist
+++ b/Nimble Templates/iOS Blank.xctemplate/TemplateInfo.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Kind</key>
+    <string>Xcode.Xcode3.ProjectTemplateUnitKind</string>
+    <key>Identifier</key>
+    <string>co.nimble.ios-template.blank</string>
+    <key>Nodes</key>
+    <array>
+        <string>.temp</string>
+    </array>
+</dict>
+</plist>

--- a/Nimble Templates/iOS Sources.xctemplate/TemplateInfo.plist
+++ b/Nimble Templates/iOS Sources.xctemplate/TemplateInfo.plist
@@ -9,126 +9,150 @@
 
 	<key>Definitions</key>
     <dict>
-        <key>Application/AppDelegate/.temp</key>
+        <key>Application/AppDelegate/temp</key>
         <dict>
 			<key>Group</key>
 			<array>
 				<string>Application</string>
 				<string>AppDelegate</string>
 			</array>
+			<key>Path</key>
+			<string>../temp/</string>
         </dict>
 
-        <key>Application/Constants/.temp</key>
+        <key>Application/Constants/temp</key>
         <dict>
 			<key>Group</key>
 			<array>
 				<string>Application</string>
 				<string>Constants</string>
 			</array>
+			<key>Path</key>
+			<string>../temp/</string>
         </dict>
 
-        <key>Application/Entitlements/.temp</key>
+        <key>Application/Entitlements/temp</key>
         <dict>
 			<key>Group</key>
 			<array>
 				<string>Application</string>
 				<string>Entitlements</string>
 			</array>
+			<key>Path</key>
+			<string>../temp/</string>
         </dict>
 
-        <key>Application/Localizations/.temp</key>
+        <key>Application/Localizations/temp</key>
         <dict>
 			<key>Group</key>
 			<array>
 				<string>Application</string>
 				<string>Localizations</string>
 			</array>
+			<key>Path</key>
+			<string>../temp/</string>
         </dict>
 
-        <key>Application/Resources/.temp</key>
+        <key>Application/Resources/temp</key>
         <dict>
 			<key>Group</key>
 			<array>
 				<string>Application</string>
 				<string>Resources</string>
 			</array>
+			<key>Path</key>
+			<string>../temp/</string>
         </dict>
 
-        <key>Extensions/.temp</key>
+        <key>Extensions/temp</key>
         <dict>
 			<key>Group</key>
 			<array>
 				<string>Extensions</string>
 			</array>
+			<key>Path</key>
+			<string>../temp/</string>
         </dict>
 
-        <key>Models/.temp</key>
+        <key>Models/temp</key>
         <dict>
 			<key>Group</key>
 			<array>
 				<string>Models</string>
 			</array>
+			<key>Path</key>
+			<string>../temp/</string>
         </dict>
 
-        <key>Modules/.temp</key>
+        <key>Modules/temp</key>
         <dict>
 			<key>Group</key>
 			<array>
 				<string>Modules</string>
 			</array>
+			<key>Path</key>
+			<string>../temp/</string>
         </dict>
 
-        <key>Protocols/.temp</key>
+        <key>Protocols/temp</key>
         <dict>
 			<key>Group</key>
 			<array>
 				<string>Protocols</string>
 			</array>
+			<key>Path</key>
+			<string>../temp/</string>
         </dict>
 
-        <key>Services/Network/.temp</key>
+        <key>Services/Network/temp</key>
         <dict>
 			<key>Group</key>
 			<array>
 				<string>Services</string>
 				<string>Network</string>
 			</array>
+			<key>Path</key>
+			<string>../temp/</string>
         </dict>
 
-        <key>Utilities/Logger/.temp</key>
+        <key>Utilities/Logger/temp</key>
         <dict>
 			<key>Group</key>
 			<array>
 				<string>Utilities</string>
 				<string>Logger</string>
 			</array>
+			<key>Path</key>
+			<string>../temp/</string>
         </dict>
 
-        <key>Views/.temp</key>
+        <key>Views/temp</key>
         <dict>
 			<key>Group</key>
 			<array>
 				<string>Views</string>
 			</array>
+			<key>Path</key>
+			<string>../temp/</string>
         </dict>
 
     </dict>
 
     <key>Nodes</key>
     <array>
-        <string>Application/AppDelegate/.temp</string>
-        <string>Application/Constants/.temp</string>
-        <string>Application/Entitlements/.temp</string>
-        <string>Application/Localizations/.temp</string>
-        <string>Application/Resources/.temp</string>
+        <string>Application/AppDelegate/temp</string>
+        <string>Application/Constants/temp</string>
+        <string>Application/Entitlements/temp</string>
+        <string>Application/Localizations/temp</string>
+        <string>Application/Resources/temp</string>
 		
-        <string>Extensions/.temp</string>
-        <string>Models/.temp</string>
-        <string>Modules/.temp</string>
-        <string>Protocols/.temp</string>
-        <string>Services/Network/.temp</string>
-        <string>Utilities/Logger/.temp</string>
-		<string>Views/.temp</string>
+        <string>Extensions/temp</string>
+        <string>Models/temp</string>
+        <string>Modules/temp</string>
+        <string>Protocols/temp</string>
+        <string>Services/Network/temp</string>
+        <string>Utilities/Logger/temp</string>
+		<string>Views/temp</string>
     </array>
 </dict>
 </plist>

--- a/Nimble Templates/iOS Sources.xctemplate/TemplateInfo.plist
+++ b/Nimble Templates/iOS Sources.xctemplate/TemplateInfo.plist
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Kind</key>
+    <string>Xcode.Xcode3.ProjectTemplateUnitKind</string>
+    <key>Identifier</key>
+    <string>co.nimble.ios-template.sources</string>
+
+	<key>Definitions</key>
+    <dict>
+        <key>Application/AppDelegate/.temp</key>
+        <dict>
+			<key>Group</key>
+			<array>
+				<string>Application</string>
+				<string>AppDelegate</string>
+			</array>
+        </dict>
+
+        <key>Application/Constants/.temp</key>
+        <dict>
+			<key>Group</key>
+			<array>
+				<string>Application</string>
+				<string>Constants</string>
+			</array>
+        </dict>
+
+        <key>Application/Entitlements/.temp</key>
+        <dict>
+			<key>Group</key>
+			<array>
+				<string>Application</string>
+				<string>Entitlements</string>
+			</array>
+        </dict>
+
+        <key>Application/Localizations/.temp</key>
+        <dict>
+			<key>Group</key>
+			<array>
+				<string>Application</string>
+				<string>Localizations</string>
+			</array>
+        </dict>
+
+        <key>Application/Resources/.temp</key>
+        <dict>
+			<key>Group</key>
+			<array>
+				<string>Application</string>
+				<string>Resources</string>
+			</array>
+        </dict>
+
+        <key>Extensions/.temp</key>
+        <dict>
+			<key>Group</key>
+			<array>
+				<string>Extensions</string>
+			</array>
+        </dict>
+
+        <key>Models/.temp</key>
+        <dict>
+			<key>Group</key>
+			<array>
+				<string>Models</string>
+			</array>
+        </dict>
+
+        <key>Modules/.temp</key>
+        <dict>
+			<key>Group</key>
+			<array>
+				<string>Modules</string>
+			</array>
+        </dict>
+
+        <key>Protocols/.temp</key>
+        <dict>
+			<key>Group</key>
+			<array>
+				<string>Protocols</string>
+			</array>
+        </dict>
+
+        <key>Services/Network/.temp</key>
+        <dict>
+			<key>Group</key>
+			<array>
+				<string>Services</string>
+				<string>Network</string>
+			</array>
+        </dict>
+
+        <key>Utilities/Logger/.temp</key>
+        <dict>
+			<key>Group</key>
+			<array>
+				<string>Utilities</string>
+				<string>Logger</string>
+			</array>
+        </dict>
+
+        <key>Views/.temp</key>
+        <dict>
+			<key>Group</key>
+			<array>
+				<string>Views</string>
+			</array>
+        </dict>
+
+    </dict>
+
+    <key>Nodes</key>
+    <array>
+        <string>Application/AppDelegate/.temp</string>
+        <string>Application/Constants/.temp</string>
+        <string>Application/Entitlements/.temp</string>
+        <string>Application/Localizations/.temp</string>
+        <string>Application/Resources/.temp</string>
+		
+        <string>Extensions/.temp</string>
+        <string>Models/.temp</string>
+        <string>Modules/.temp</string>
+        <string>Protocols/.temp</string>
+        <string>Services/Network/.temp</string>
+        <string>Utilities/Logger/.temp</string>
+		<string>Views/.temp</string>
+    </array>
+</dict>
+</plist>

--- a/Nimble Templates/iOS Tests.xctemplate/TemplateInfo.plist
+++ b/Nimble Templates/iOS Tests.xctemplate/TemplateInfo.plist
@@ -9,28 +9,32 @@
 
 	<key>Definitions</key>
     <dict>
-        <key>UnitTests/.temp</key>
+        <key>UnitTests/temp</key>
         <dict>
 			<key>Group</key>
 			<array>
 				<string>UnitTests</string>
 			</array>
+			<key>Path</key>
+			<string>../temp/</string>
         </dict>
 
-        <key>UITests/.temp</key>
+        <key>UITests/temp</key>
         <dict>
 			<key>Group</key>
 			<array>
 				<string>UITests</string>
 			</array>
+			<key>Path</key>
+			<string>../temp/</string>
         </dict>
 
     </dict>
 
     <key>Nodes</key>
     <array>
-        <string>UnitTests/.temp</string>
-        <string>UITests/.temp</string>
+        <string>UnitTests/temp</string>
+        <string>UITests/temp</string>
     </array>
 </dict>
 </plist>

--- a/Nimble Templates/iOS Tests.xctemplate/TemplateInfo.plist
+++ b/Nimble Templates/iOS Tests.xctemplate/TemplateInfo.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Kind</key>
+    <string>Xcode.Xcode3.ProjectTemplateUnitKind</string>
+    <key>Identifier</key>
+    <string>co.nimble.ios-template.tests</string>
+
+	<key>Definitions</key>
+    <dict>
+        <key>UnitTests/.temp</key>
+        <dict>
+			<key>Group</key>
+			<array>
+				<string>UnitTests</string>
+			</array>
+        </dict>
+
+        <key>UITests/.temp</key>
+        <dict>
+			<key>Group</key>
+			<array>
+				<string>UITests</string>
+			</array>
+        </dict>
+
+    </dict>
+
+    <key>Nodes</key>
+    <array>
+        <string>UnitTests/.temp</string>
+        <string>UITests/.temp</string>
+    </array>
+</dict>
+</plist>

--- a/Nimble Templates/temp/.gitignore
+++ b/Nimble Templates/temp/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/install.sh
+++ b/install.sh
@@ -4,3 +4,4 @@ mkdir -p ~/Library/Developer/Xcode/Templates/File\ Templates
 mkdir -p ~/Library/Developer/Xcode/Templates/Project\ Templates
 mkdir -p ~/Library/Developer/Xcode/Templates/Project\ Templates/Nimble\ Templates
 cp -R Nimble\ Templates/* ~/Library/Developer/Xcode/Templates/Project\ Templates/Nimble\ Templates
+find ~/Library/Developer/Xcode/Templates/Project\ Templates/Nimble\ Templates/temp -name ".gitignore" -delete


### PR DESCRIPTION
https://github.com/nimbl3/ios-templates/issues/106

## What happened

### Why

We already have the standard file organization for iOS template on wiki: https://github.com/nimblehq/ios-templates/wiki/Standard-file-organization-🗂

Please config the structure into App.xctemplates

### Acceptance Criteria

Configure file `TemplateInfo.plist` to create our structure folders

Note: A good resource to follow - https://useyourloaf.com/blog/creating-custom-xcode-project-templates/
 
## Insight

We can do this in 2 ways
- Group (Yellow): at current research status, it's only possible to create yellow folder with file inside, not an empty one.
- Folder (Blue): possible to create blue folder without file and also easier to create.

We're using yellow folder but could change to blue one. We also can use a script to remove those file instead.
 
## Proof Of Work
<img width="1512" alt="Screen Shot 2020-09-28 at 19 16 15" src="https://user-images.githubusercontent.com/6356137/94505512-7090eb80-0235-11eb-9466-0c23c6d4fa79.png">
