### PR TITLE
[113] As an iOS developer, we should enable build with bitcode for Production only

### DIFF
--- a/Nimble Templates/App.xctemplate/TemplateInfo.plist
+++ b/Nimble Templates/App.xctemplate/TemplateInfo.plist
@@ -41,6 +41,8 @@
 				<string>___VARIABLE_bundleIdentifierPrefix:bundleIdentifier___.___PACKAGENAMEASRFC1034IDENTIFIER___.staging</string>
 				<key>PRODUCT_NAME</key>
 				<string>$(TARGET_NAME) Staging</string>
+				<key>ENABLE_BITCODE</key>
+				<string>NO</string>
 			</dict>
 			<key>Staging</key>
 			<dict>
@@ -62,6 +64,8 @@
 				<string>___VARIABLE_bundleIdentifierPrefix:bundleIdentifier___.___PACKAGENAMEASRFC1034IDENTIFIER___.staging</string>
 				<key>PRODUCT_NAME</key>
 				<string>$(TARGET_NAME) Staging</string>
+				<key>ENABLE_BITCODE</key>
+				<string>NO</string>
 			</dict>
 			<key>Dev UAT</key>
 			<dict>
@@ -86,6 +90,8 @@
 				<string>___VARIABLE_bundleIdentifierPrefix:bundleIdentifier___.___PACKAGENAMEASRFC1034IDENTIFIER___.uat</string>
 				<key>PRODUCT_NAME</key>
 				<string>$(TARGET_NAME) UAT</string>
+				<key>ENABLE_BITCODE</key>
+				<string>NO</string>
 			</dict>
 			<key>UAT</key>
 			<dict>
@@ -103,6 +109,8 @@
 				<string>___VARIABLE_bundleIdentifierPrefix:bundleIdentifier___.___PACKAGENAMEASRFC1034IDENTIFIER___.uat</string>
 				<key>PRODUCT_NAME</key>
 				<string>$(TARGET_NAME) UAT</string>
+				<key>ENABLE_BITCODE</key>
+				<string>NO</string>
 			</dict>
 			<key>Dev Production</key>
 			<dict>
@@ -125,6 +133,8 @@
 				<string>___VARIABLE_bundleIdentifierPrefix:bundleIdentifier___.___PACKAGENAMEASRFC1034IDENTIFIER___</string>
 				<key>PRODUCT_NAME</key>
 				<string>$(TARGET_NAME)</string>
+				<key>ENABLE_BITCODE</key>
+				<string>NO</string>
 			</dict>
 			<key>Production</key>
 			<dict>
@@ -146,6 +156,8 @@
 				<string>___VARIABLE_bundleIdentifierPrefix:bundleIdentifier___.___PACKAGENAMEASRFC1034IDENTIFIER___</string>
 				<key>PRODUCT_NAME</key>
 				<string>$(TARGET_NAME)</string>
+				<key>ENABLE_BITCODE</key>
+				<string>YES</string>
 			</dict>
 		</dict>
 	</dict>


### PR DESCRIPTION
https://github.com/nimbl3/ios-templates/issues/113

## What happened

We should enable build with bitcode for Production only.

| | Enable Bitcode |
|---|---|
| Dev UAT |  |
| UAT |  |
| Dev Staging |  |
| Staging |  |
| Dev Production |  |
| Production | x |
 
## Proof Of Work

![Screen Shot 2020-10-22 at 16 59 47](https://user-images.githubusercontent.com/23162627/96856683-635bcb00-1488-11eb-8632-2dcbad198144.png)

