### PR TITLE
[124] Configured bundle identifiers not set to bundle identifiers of newly created project.

### DIFF
--- a/Nimble Templates/App Base.xctemplate/TemplateInfo.plist
+++ b/Nimble Templates/App Base.xctemplate/TemplateInfo.plist
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Kind</key>
+    <string>Xcode.Xcode3.ProjectTemplateUnitKind</string>
+    <key>Identifier</key>
+    <string>co.nimblehq.dt.unit.applicationBase</string>
+    <key>Ancestors</key>
+    <array>
+        <string>co.nimblehq.dt.unit.bundleBase</string>
+    </array>
+    <key>Targets</key>
+    <array>
+        <dict>
+            <key>ProductType</key>
+            <string>com.apple.product-type.application</string>
+            <key>BuildPhases</key>
+            <array>
+                <dict>
+                    <key>Class</key>
+                    <string>Sources</string>
+                </dict>
+                <dict>
+                    <key>Class</key>
+                    <string>Frameworks</string>
+                </dict>
+                <dict>
+                    <key>Class</key>
+                    <string>Resources</string>
+                </dict>
+            </array>
+        </dict>
+    </array>
+    <key>Options</key>
+    <array>
+        <dict>
+            <key>Identifier</key>
+            <string>languageChoice</string>
+            <key>Units</key>
+            <dict>
+                <key>Swift</key>
+                <dict>
+                    <key>Definitions</key>
+                    <dict>
+                        <key>main.swift</key>
+                        <dict>
+                            <key>SortOrder</key>
+                            <integer>999</integer>
+                        </dict>
+                        <key>main.swift:main</key>
+                        <dict>
+                            <key>Beginning</key>
+                            <string/>
+                            <key>End</key>
+                            <string/>
+                        </dict>
+                    </dict>
+                </dict>
+            </dict>
+        </dict>
+    </array>
+    <key>Definitions</key>
+    <dict>
+        <!-- This is defined globally for templates that don't want language choice -->
+        <key>main.m</key>
+        <dict>
+            <key>SortOrder</key>
+            <integer>999</integer>
+        </dict>
+        <key>main.m:main</key>
+        <dict>
+            <key>Beginning</key>
+            <string>int main(int argc, const char * argv[]) {</string>
+            <key>End</key>
+            <string>}</string>
+            <key>Indent</key>
+            <integer>1</integer>
+        </dict>
+    </dict>
+</dict>
+</plist>

--- a/Nimble Templates/App.xctemplate/TemplateInfo.plist
+++ b/Nimble Templates/App.xctemplate/TemplateInfo.plist
@@ -8,7 +8,7 @@
 	<string>co.nimblehq.dt.unit.singleViewApplication</string>
 	<key>Ancestors</key>
 	<array>
-		<string>co.nimble.dt.unit.cocoaTouchApplicationBase</string>
+		<string>co.nimblehq.dt.unit.cocoaTouchApplicationBase</string>
 	</array>
 	<key>Concrete</key>
 	<true/>

--- a/Nimble Templates/Bundle Base.xctemplate/TemplateInfo.plist
+++ b/Nimble Templates/Bundle Base.xctemplate/TemplateInfo.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Kind</key>
+    <string>Xcode.Xcode3.ProjectTemplateUnitKind</string>
+    <key>Identifier</key>
+    <string>co.nimblehq.dt.unit.bundleBase</string>
+    <key>Ancestors</key>
+    <array>
+        <string>com.apple.dt.unit.base</string>
+    </array>
+    <key>Targets</key>
+    <array>
+        <dict>
+            <key>SharedSettings</key>
+            <dict>
+                <key>INFOPLIST_FILE</key>
+                <string>___PACKAGENAME___/Info.plist</string>
+                <key>PRODUCT_BUNDLE_IDENTIFIER</key>
+                <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+            </dict>
+        </dict>
+    </array>
+    <key>Nodes</key>
+    <array>
+        <string>Info.plist:Identifier</string>
+        <string>Info.plist:PlistVersion</string>
+        <string>Info.plist:Executable</string>
+        <string>Info.plist:BundleName</string>
+        <string>Info.plist:DevelopmentRegion</string>
+        <string>Info.plist:PackageType</string>
+        <string>Info.plist:ProductVersion</string>
+    </array>
+</dict>
+</plist>

--- a/Nimble Templates/Cocoa Touch App Base.xctemplate/TemplateInfo.plist
+++ b/Nimble Templates/Cocoa Touch App Base.xctemplate/TemplateInfo.plist
@@ -5,10 +5,10 @@
 	<key>Kind</key>
 	<string>Xcode.Xcode3.ProjectTemplateUnitKind</string>
 	<key>Identifier</key>
-	<string>co.nimble.dt.unit.cocoaTouchApplicationBase</string>
+	<string>co.nimblehq.dt.unit.cocoaTouchApplicationBase</string>
 	<key>Ancestors</key>
 	<array>
-		<string>com.apple.dt.unit.applicationBase</string>
+		<string>co.nimblehq.dt.unit.applicationBase</string>
 		<string>com.apple.dt.unit.iosBase</string>
 		<string>com.apple.dt.unit.languageChoice.app.iOS</string>
 		<string>com.apple.dt.unit.appLifecycle.iOS</string>


### PR DESCRIPTION
https://github.com/nimbl3/ios-templates/issues/124

## What happened

👆
 
## Insight

Bundler identifier not takes configured identifier in Nimble iOS template. Instead it takes bundle identifier from `com.apple.dt.unit.bundleBase`
<img width="1194" alt="Screen Shot 2020-12-21 at 15 12 13" src="https://user-images.githubusercontent.com/22606906/102754057-f5a42080-439e-11eb-990b-2a34b0296fa3.png">

which disabled our bundle identifier configurations.
<img width="1099" alt="Screen Shot 2020-12-21 at 15 04 25" src="https://user-images.githubusercontent.com/22606906/102753430-dbb60e00-439d-11eb-9649-533681b35fa6.png">

Describe in details how to test the changes; referenced documentation is welcome as well.
 
## Proof Of Work

<img width="1265" alt="Screen Shot 2020-12-21 at 15 27 43" src="https://user-images.githubusercontent.com/22606906/102757031-4a499a80-43a3-11eb-8965-49b9f96e821a.png">

