### PR TITLE
[179] Incorrect build configuration setup

### DIFF
--- a/Tuist/ProjectDescriptionHelpers/ProjectBuildConfiguration.swift
+++ b/Tuist/ProjectDescriptionHelpers/ProjectBuildConfiguration.swift
@@ -7,7 +7,7 @@ public enum ProjectBuildConfiguration: CaseIterable {
     case debugProduction
     case releaseProduction
 
-    private var name: String {
+    var name: String {
         switch self {
         case .debugStaging: return "Debug Staging"
         case .releaseStaging: return "Release Staging"
@@ -20,13 +20,13 @@ public enum ProjectBuildConfiguration: CaseIterable {
         let rootPath = "Configurations/XCConfigs/"
         switch self {
             case .debugStaging:
-                return rootPath += "DebugStaging.xcconfig"
+                return "\(rootPath)DebugStaging.xcconfig"
             case .releaseStaging:
-                return rootPath += "ReleaseStaging.xcconfig"
+                return "\(rootPath)ReleaseStaging.xcconfig"
             case .debugProduction:
-                return rootPath += "DebugProduction.xcconfig"
+                return "\(rootPath)DebugProduction.xcconfig"
             case .releaseProduction:
-                return rootPath += "ReleaseProduction.xcconfig"
+                return "\(rootPath)ReleaseProduction.xcconfig"
         }
     }
 

--- a/Tuist/ProjectDescriptionHelpers/Scheme+Initializing.swift
+++ b/Tuist/ProjectDescriptionHelpers/Scheme+Initializing.swift
@@ -4,35 +4,39 @@ extension Scheme {
 
     public static func productionScheme(name: String) -> Scheme {
         #warning("We should use Debug Production and Release Production instead after implement build configurations")
+        let debugConfigName = ProjectBuildConfiguration.debugProduction.name
+        let releaseConfigName = ProjectBuildConfiguration.releaseProduction.name
         return Scheme(
             name: name,
             shared: true,
             buildAction: BuildAction(targets: ["\(name)"]),
             testAction: TestAction(
                 targets: ["\(name)Tests", "\(name)UITests"],
-                configurationName: ProjectBuildConfiguration.debugProduction.name
+                configurationName: debugConfigName
             ),
-            runAction: RunAction(configurationName: ProjectBuildConfiguration.debugProduction.name),
-            archiveAction: ArchiveAction(configurationName: ProjectBuildConfiguration.releaseProduction.name),
-            profileAction: ProfileAction(configurationName: ProjectBuildConfiguration.debugProduction.name),
-            analyzeAction: AnalyzeAction(configurationName: ProjectBuildConfiguration.debugProduction.name)
+            runAction: RunAction(configurationName: debugConfigName),
+            archiveAction: ArchiveAction(configurationName: releaseConfigName),
+            profileAction: ProfileAction(configurationName: debugConfigName),
+            analyzeAction: AnalyzeAction(configurationName: debugConfigName)
         )
     }
 
     public static func stagingScheme(name: String) -> Scheme {
         #warning("We should use Debug Staging and Release Staging instead after implement build configurations")
+        let debugConfigName = ProjectBuildConfiguration.debugStaging.name
+        let releaseConfigName = ProjectBuildConfiguration.releaseStaging.name
         return Scheme(
             name: "\(name) Staging",
             shared: true,
             buildAction: BuildAction(targets: ["\(name)"]),
             testAction: TestAction(
                 targets: ["\(name)Tests", "\(name)UITests"],
-                configurationName: ProjectBuildConfiguration.debugStaging.name
+                configurationName: debugConfigName
             ),
-            runAction: RunAction(configurationName: ProjectBuildConfiguration.debugStaging.name),
-            archiveAction: ArchiveAction(configurationName: ProjectBuildConfiguration.releaseStaging.name),
-            profileAction: ProfileAction(configurationName: ProjectBuildConfiguration.debugStaging.name),
-            analyzeAction: AnalyzeAction(configurationName: ProjectBuildConfiguration.debugStaging.name)
+            runAction: RunAction(configurationName: debugConfigName),
+            archiveAction: ArchiveAction(configurationName: releaseConfigName),
+            profileAction: ProfileAction(configurationName: debugConfigName),
+            analyzeAction: AnalyzeAction(configurationName: debugConfigName)
         )
     }
 }

--- a/Tuist/ProjectDescriptionHelpers/Scheme+Initializing.swift
+++ b/Tuist/ProjectDescriptionHelpers/Scheme+Initializing.swift
@@ -3,7 +3,6 @@ import ProjectDescription
 extension Scheme {
 
     public static func productionScheme(name: String) -> Scheme {
-        #warning("We should use Debug Production and Release Production instead after implement build configurations")
         let debugConfigName = ProjectBuildConfiguration.debugProduction.name
         let releaseConfigName = ProjectBuildConfiguration.releaseProduction.name
         return Scheme(
@@ -22,7 +21,6 @@ extension Scheme {
     }
 
     public static func stagingScheme(name: String) -> Scheme {
-        #warning("We should use Debug Staging and Release Staging instead after implement build configurations")
         let debugConfigName = ProjectBuildConfiguration.debugStaging.name
         let releaseConfigName = ProjectBuildConfiguration.releaseStaging.name
         return Scheme(

--- a/Tuist/ProjectDescriptionHelpers/Scheme+Initializing.swift
+++ b/Tuist/ProjectDescriptionHelpers/Scheme+Initializing.swift
@@ -10,12 +10,12 @@ extension Scheme {
             buildAction: BuildAction(targets: ["\(name)"]),
             testAction: TestAction(
                 targets: ["\(name)Tests", "\(name)UITests"],
-                configurationName: "Debug"
+                configurationName: ProjectBuildConfiguration.debugProduction.name
             ),
-            runAction: RunAction(configurationName: "Debug"),
-            archiveAction: ArchiveAction(configurationName: "Release"),
-            profileAction: ProfileAction(configurationName: "Debug"),
-            analyzeAction: AnalyzeAction(configurationName: "Debug")
+            runAction: RunAction(configurationName: ProjectBuildConfiguration.debugProduction.name),
+            archiveAction: ArchiveAction(configurationName: ProjectBuildConfiguration.releaseProduction.name),
+            profileAction: ProfileAction(configurationName: ProjectBuildConfiguration.debugProduction.name),
+            analyzeAction: AnalyzeAction(configurationName: ProjectBuildConfiguration.debugProduction.name)
         )
     }
 
@@ -27,12 +27,12 @@ extension Scheme {
             buildAction: BuildAction(targets: ["\(name)"]),
             testAction: TestAction(
                 targets: ["\(name)Tests", "\(name)UITests"],
-                configurationName: "Debug"
+                configurationName: ProjectBuildConfiguration.debugStaging.name
             ),
-            runAction: RunAction(configurationName: "Debug"),
-            archiveAction: ArchiveAction(configurationName: "Release"),
-            profileAction: ProfileAction(configurationName: "Debug"),
-            analyzeAction: AnalyzeAction(configurationName: "Debug")
+            runAction: RunAction(configurationName: ProjectBuildConfiguration.debugStaging.name),
+            archiveAction: ArchiveAction(configurationName: ProjectBuildConfiguration.releaseStaging.name),
+            profileAction: ProfileAction(configurationName: ProjectBuildConfiguration.debugStaging.name),
+            analyzeAction: AnalyzeAction(configurationName: ProjectBuildConfiguration.debugStaging.name)
         )
     }
 }


### PR DESCRIPTION
https://github.com/nimblehq/ios-templates/issues/179

## What happened

There are bugs that won't allow us to create a new project with the  ios template:
- Incorrect xcconfig path.
- Incorrect setup of build configuration for schemes.
 
## Insight

- Fix computed property path in `ProjectBuildConfiguration` enum.
- Update build configuration for schemes in `Scheme+Initializing` 
 
## Proof Of Work

![Screen Shot 2021-08-31 at 15 36 38](https://user-images.githubusercontent.com/22606906/131471061-fc9b43c4-ad4e-4039-8add-9a6f46c22e05.png)
![Screen Shot 2021-08-31 at 15 36 44](https://user-images.githubusercontent.com/22606906/131471073-8f06a712-e1fa-49d0-b8b3-fdc6df991e2e.png)
![Screen Shot 2021-08-31 at 15 36 55](https://user-images.githubusercontent.com/22606906/131471078-d7fd7d19-bd1c-4dca-8480-9b4679f1a69f.png)
![Screen Shot 2021-08-31 at 15 37 01](https://user-images.githubusercontent.com/22606906/131471081-2be6a166-774f-427f-b651-5d192538c337.png)

