### PR TITLE
[181] [Chore] Add Github issue creation templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -1,0 +1,20 @@
+---
+name: "Bug Report"
+about: "You found something that is not working. Report it so that it can be fixed. 👷‍"
+title: "Fix: "
+labels: "type : bug"
+---
+
+## Issue
+
+Describe the issue you are facing. Show us the implementation: screenshots, gif, etc.
+ 
+## Expected
+
+Describe what should be the correct behaviour.
+ 
+## Steps to reproduce
+
+1. 
+2. 
+3. 

--- a/.github/ISSUE_TEMPLATE/chore_template.md
+++ b/.github/ISSUE_TEMPLATE/chore_template.md
@@ -1,0 +1,14 @@
+---
+name: "Chore"
+about: "Open a Chore for minor update."
+title: "Update "
+labels: "type : chore"
+---
+
+## Why
+
+Describe the update details and why it's needed. 
+ 
+## Who Benefits?
+
+Describe who will be the beneficiaries e.g. everyone, specific chapters, clients...

--- a/.github/ISSUE_TEMPLATE/feature_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_template.md
@@ -1,0 +1,14 @@
+---
+name: "Feature"
+about: "Open a feature issue to add new functionalities."
+title: "Add "
+labels: "type : feature"
+---
+
+## Why
+
+Describe the big picture of the feature and why it's needed. 
+ 
+## Who Benefits?
+
+Describe who will be the beneficiaries e.g. everyone, specific chapters, clients...

--- a/.github/ISSUE_TEMPLATE/story_template.md
+++ b/.github/ISSUE_TEMPLATE/story_template.md
@@ -1,0 +1,22 @@
+---
+name: "Story"
+about: "Open a feature story"
+title: "[Type] As a user, I can "
+labels: "type : feature"
+---
+
+## Why
+
+Describe the idea of the user story as in what the motive of the user story is.
+
+## Acceptance Criteria
+
+List down how the user story will be tested and what criteria are necessary for the user story to be accepted.
+
+## Design
+
+(Optional) Add design screenshots or Figma links for UI/UX-related stories.
+
+## Resources
+
+(Optional) Add useful resources such as links to documentation, implementation ideas, or best practices.


### PR DESCRIPTION
Resolves https://github.com/nimblehq/ios-templates/issues/181

## What happened

- Add issue templates when creating a new issue: Bug Report, Chore, Feature, Story
 
## Insight

`N/A`
 
## Proof Of Work

`N/A`
