### PR TITLE
[#191] [Bitrise] Add tools for Automated Pull Request Review to CI/CD templates

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -123,7 +123,15 @@ workflows:
     - git-clone@6.1: {}
     - cache-pull@2: {}
     - cocoapods-install@2: {}
-    - xcode-test@3.0: {}
+    - fastlane@3:
+        inputs:
+        - lane: build_and_test
+    - fastlane@3:
+        inputs:
+        - lane: run_xcov
+    - danger@2:
+        inputs:
+        - github_api_token: $DANGER_GITHUB_API_TOKEN
     - cache-push@2:
         inputs:
         - cache_paths: |-


### PR DESCRIPTION
https://github.com/nimblehq/ios-templates/issues/191

## What happened

While each platform has specific requirements for its Continuous Integration pipelines, automated linters and code checks (security, code smells) must be made standard across all platforms. iOS is lagging behind in this regard. Simultaneously, the iOS chapter should adopt the same tooling to limit the number of different tools we need to manage at the team level.

The Web Chapter already uses Danger to automate code review comments from linters and code checks. Since it is a proven tool even written in Swift (recently released) projects, the mobile chapters should adopt it.
 
## Insight

In this pull request:
- Add `build_and_test`, `xcov` lanes into bitrise.yml
- Add danger in bitrise.yml
- I updated the name of workflow from `test` to `automatic_pull_request_review`

I suggest using the `Split` mode to easy to review this pull request
 
## Proof Of Work

N/A because our templates didn't apply Bitrise. I will try on another repository then update later in case having any issues.
