### PR TITLE
[#213] Swiftformat lint

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,5 +1,5 @@
 # file options
---exclude Pods, Generated
+--exclude Pods, Generated, **/*.generated.swift
 
 # rules
 --disable fileHeader
@@ -8,3 +8,4 @@
 --disable wrapEnumCases
 --disable wrapMultilineStatementBraces
 --disable wrapSwitchCases
+--disable blankLinesAtStartOfScope

--- a/Tuist/ProjectDescriptionHelpers/Target+Initializing.swift
+++ b/Tuist/ProjectDescriptionHelpers/Target+Initializing.swift
@@ -20,6 +20,7 @@ extension Target {
                 TargetAction.sourceryAction(),
                 TargetAction.rswiftAction(),
                 TargetAction.swiftLintAction(),
+                TargetAction.swiftFormatLintAction(),
                 TargetAction.firebaseAction()
             ]
         )

--- a/Tuist/ProjectDescriptionHelpers/TargetAction+Initializing.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetAction+Initializing.swift
@@ -50,6 +50,19 @@ extension TargetAction {
         )
     }
 
+    public static func swiftFormatLintAction() -> TargetAction {
+        let runSwiftFormat = """
+        if [ -z "$CI" ]; then
+            "${PODS_ROOT}/SwiftFormat/CommandLineTool/swiftformat" "$SRCROOT" --lint --lenient
+        fi
+        """
+        return .pre(
+            script: runSwiftFormat,
+            name: "SwiftFormat Lint",
+            basedOnDependencyAnalysis: true
+        )
+    }
+
     public static func firebaseAction() -> TargetAction {
         let script = """
         PATH_TO_GOOGLE_PLISTS="$SRCROOT/$PROJECT_NAME/Configurations/Plists/GoogleService"


### PR DESCRIPTION
close #213 

## What happened

Add swiftformat listing to build phase.
 
## Insight

Disable `blankLinesAtStartOfScope` because it does not align with our convention.
 
## Proof Of Work



<img width="1512" alt="Screen Shot 2021-10-20 at 15 20 15" src="https://user-images.githubusercontent.com/6356137/138056914-ca5c32ec-27de-4fb1-b824-9ecfdb8054ea.png">