### PR TITLE
[#215] New work flow for release firebase

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -92,7 +92,7 @@ workflows:
     - firebase-app-distribution@0:
         inputs:
         - firebase_token: "$FIREBASE_CI_TOKEN"
-        - app: "$FIREBASE_APP_ID_STAGING"
+        - app: "$FIREBASE_APP_ID_PRD"
     - firebase-dsym-upload@2:
         inputs:
         - fdu_google_services_location: "$GOOGLE_SERVICE_INFO_PLIST_PATH"


### PR DESCRIPTION
https://github.com/nimblehq/ios-templates/issues/215

## What happened

When having a new commit to `release` branch it automatically deploys the new build to the Firebase.
 
## Insight

- Add new workflow named `deploy_release_firebase`
- Add a new trigger for `release` branch that will run `deploy_release_firebase`
- Rename `deploy_appstore` to `deploy_app_store`
 
## Proof Of Work
This POW from a different repo and the test step has been removed due to the time limit of the Bitrise free plan.
![Screen Shot 2021-10-25 at 17 09 25](https://user-images.githubusercontent.com/22606906/138678891-0d43643e-52f7-4ded-9fee-b206da568e46.png)

