### PR TITLE
[#221] Include ignore SwiftLint file_name for extensions Files.

### DIFF
--- a/{PROJECT_NAME}/Sources/Constants/Constants+API.swift
+++ b/{PROJECT_NAME}/Sources/Constants/Constants+API.swift
@@ -1,3 +1,4 @@
+//  swiftlint:disable:this file_name
 //
 //  Constants+API.swift
 //

--- a/{PROJECT_NAME}/Sources/Supports/Extensions/UIKit/Color+Application.swift
+++ b/{PROJECT_NAME}/Sources/Supports/Extensions/UIKit/Color+Application.swift
@@ -1,3 +1,4 @@
+//  swiftlint:disable:this file_name
 //
 //  UIColor+Application.swift
 //

--- a/{PROJECT_NAME}/Sources/Supports/Helpers/Typealiases/Typealiases.swift
+++ b/{PROJECT_NAME}/Sources/Supports/Helpers/Typealiases/Typealiases.swift
@@ -1,3 +1,4 @@
+//  swiftlint:disable:this file_name
 //
 //  Typealiases.swift
 //


### PR DESCRIPTION
close #221 

## What happened

Add ignore file_name to extension
 
## Insight

These files would never conform to `file_name` rule by their nature.
 
## Proof Of Work

Wait for CI.