### PR TITLE
[#208] Fix: R.generated.swift need to be created to include into project

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,7 +5,7 @@ included:
 
 excluded:
   - {PROJECT_NAME}Tests/Sources/Mocks/Sourcery/AutoMockable.generated.swift
-  - {PROJECT_NAME}/Sources/Supports/Helpers/R.swift/R.generated.swift
+  - {PROJECT_NAME}/Sources/Supports/Helpers/Rswift/R.generated.swift
   - Pods
   - Derived
   - DerivedData

--- a/Tuist/ProjectDescriptionHelpers/TargetAction+Initializing.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetAction+Initializing.swift
@@ -14,7 +14,7 @@ extension TargetAction {
     public static func rswiftAction() -> TargetAction {
         let rswiftPath = "$PODS_ROOT/R.swift/rswift"
         let inputPath = "$TEMP_DIR/rswift-lastrun"
-        let outputPath = "$SRCROOT/$PROJECT_NAME/Sources/Supports/Helpers/R.swift/R.generated.swift"
+        let outputPath = "$SRCROOT/$PROJECT_NAME/Sources/Supports/Helpers/Rswift/R.generated.swift"
         return .pre(
             script: "\"\(rswiftPath)\" generate \"\(outputPath)\"",
             name: "R.swift",

--- a/make.sh
+++ b/make.sh
@@ -117,6 +117,9 @@ rename_folder "${CONSTANT_PROJECT_NAME}" "${PROJECT_NAME_NO_SPACES}"
 mkdir -p "${PROJECT_NAME_NO_SPACES}Tests/Sources/Mocks/Sourcery"
 touch "${PROJECT_NAME_NO_SPACES}Tests/Sources/Mocks/Sourcery/AutoMockable.generated.swift"
 
+# Add R.generated.swift file
+touch "${PROJECT_NAME_NO_SPACES}/Sources/Supports/Helpers/Rswift/R.generated.swift"
+
 echo "✅  Completed"
 
 # Search and replace in files

--- a/make.sh
+++ b/make.sh
@@ -118,6 +118,7 @@ mkdir -p "${PROJECT_NAME_NO_SPACES}Tests/Sources/Mocks/Sourcery"
 touch "${PROJECT_NAME_NO_SPACES}Tests/Sources/Mocks/Sourcery/AutoMockable.generated.swift"
 
 # Add R.generated.swift file
+mkdir -p "${PROJECT_NAME_NO_SPACES}/Sources/Supports/Helpers/Rswift"
 touch "${PROJECT_NAME_NO_SPACES}/Sources/Supports/Helpers/Rswift/R.generated.swift"
 
 echo "✅  Completed"


### PR DESCRIPTION
https://github.com/nimblehq/ios-templates/issues/208

## What happened

- Add `R.generated.swift` reference into Xcode project
 
## Insight

Due to `R.generated.swift` is ignored, it will be added before Tuist generates into `make.sh`
 
## Proof Of Work
![Screen Shot 2021-11-24 at 14 03 48](https://user-images.githubusercontent.com/17875522/143190934-75d0d30d-d331-408c-b4f7-ceacee92da1e.png)


