### PR TITLE
[#235] Fix: Add master branch for trigger publish_docs_to_wiki workflow

### DIFF
--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -6,6 +6,7 @@ on:
       - docs/**
     branches:
       - main
+      - master
 
 env:
   USER_TOKEN: ${{ secrets.NIMBLE_DEV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ DerivedData
 
 # Tuist
 .tuist-generated
+
+# JetBrains IDEs
+
+.idea


### PR DESCRIPTION
https://github.com/nimblehq/ios-templates/issues/235

## What happened

In the publish_docs_to_wiki workflow, it's triggered with the main branch, however, this repository has a master branch instead, we need to update the workflow.
 
## Insight

- Add `master` branch into the workflow
 
## Proof Of Work

N/A
