### PR TITLE
[250] [Bug] Fix: Only update development profiles when registering a new device

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -58,7 +58,12 @@ platform :ios do
 
   desc 'Sync Development match signing'
   lane :sync_development_signing do
-    match_manager.sync_development_signing(app_identifier: [Constants.BUNDLE_ID_STAGING])
+      match_manager.sync_development_signing(
+        app_identifier: [
+          Constants.BUNDLE_ID_STAGING,
+          Constants.BUNDLE_ID_PRODUCTION
+        ]
+      )
   end
 
   desc 'Sync Adhoc match signing'
@@ -83,7 +88,7 @@ platform :ios do
     device_hash = {}
     device_hash[device_name] = device_udid
     register_devices(devices: device_hash)
-    
+
     match(type: "development", force: true)
     match(type: "adhoc", force: true)
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -56,6 +56,11 @@ platform :ios do
 
   # Code Sign
 
+  desc 'Sync Development match signing'
+  lane :sync_development_signing do
+    match_manager.sync_development_signing(app_identifier: [Constants.BUNDLE_ID_STAGING])
+  end
+
   desc 'Sync Adhoc match signing'
   lane :sync_adhoc_signing do
     match_manager.sync_adhoc_signing(app_identifier: [Constants.BUNDLE_ID_STAGING])
@@ -78,7 +83,9 @@ platform :ios do
     device_hash = {}
     device_hash[device_name] = device_udid
     register_devices(devices: device_hash)
-    match(force: true)
+    
+    match(type: "development", force: true)
+    match(type: "adhoc", force: true)
   end
 
   # Firebase

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -89,8 +89,8 @@ platform :ios do
     device_hash[device_name] = device_udid
     register_devices(devices: device_hash)
 
-    match(type: "development", force: true)
-    match(type: "adhoc", force: true)
+    match_manager.sync_development_signing(app_identifier: nil, force: true)
+    match_manager.sync_adhoc_signing(app_identifier: nil, force: true)
   end
 
   # Firebase

--- a/fastlane/Managers/MatchManager.rb
+++ b/fastlane/Managers/MatchManager.rb
@@ -13,7 +13,7 @@ class MatchManager
     @is_ci = is_ci
   end
 
-  def sync_development_signing(app_identifier:)
+  def sync_development_signing(app_identifier:, force: false)
     if @is_ci
       create_ci_keychain
       @fastlane.match(
@@ -21,14 +21,15 @@ class MatchManager
         keychain_name: @keychain_name,
         keychain_password: @keychain_password,
         app_identifier: app_identifier,
-        readonly: true
+        readonly: !force,
+        force: force
       )
     else
-      @fastlane.match(type: 'development', app_identifier: app_identifier, readonly: true)
+      @fastlane.match(type: 'development', app_identifier: app_identifier, readonly: !force, force: force)
     end
   end
-  
-  def sync_adhoc_signing(app_identifier:)
+
+  def sync_adhoc_signing(app_identifier:, force: false)
     if @is_ci
       create_ci_keychain
       @fastlane.match(
@@ -36,10 +37,11 @@ class MatchManager
         keychain_name: @keychain_name,
         keychain_password: @keychain_password,
         app_identifier: app_identifier,
-        readonly: true
+        readonly: !force,
+        force: force
       )
     else
-      @fastlane.match(type: 'adhoc', app_identifier: app_identifier, readonly: true)
+      @fastlane.match(type: 'adhoc', app_identifier: app_identifier, readonly: !force, force: force)
     end
   end
 

--- a/fastlane/Managers/MatchManager.rb
+++ b/fastlane/Managers/MatchManager.rb
@@ -13,6 +13,21 @@ class MatchManager
     @is_ci = is_ci
   end
 
+  def sync_development_signing(app_identifier:)
+    if @is_ci
+      create_ci_keychain
+      @fastlane.match(
+        type: 'development',
+        keychain_name: @keychain_name,
+        keychain_password: @keychain_password,
+        app_identifier: app_identifier,
+        readonly: true
+      )
+    else
+      @fastlane.match(type: 'development', app_identifier: app_identifier, readonly: true)
+    end
+  end
+  
   def sync_adhoc_signing(app_identifier:)
     if @is_ci
       create_ci_keychain


### PR DESCRIPTION
https://github.com/nimblehq/ios-templates/issues/250

## What happened

- Update `adhoc` provisioning profile when registering a new device
- Add sync development provisioning profile lane
 
## Insight

- When turning on the `Push Notifications` feature, the development environment will require property provisioning profiles, so we will need to create and sync these provisioning profiles to be able to build and debug
- For new updates on `register_new_device`,  I am unable to test due to don't having an Apple Developer account
 
## Proof Of Work

<details>
  <summary>bundle exec fastlane sync_development_signing</summary>
  
```
[✔] 🚀 
+------------------------+---------+------------------------+
|                       Used plugins                        |
+------------------------+---------+------------------------+
| Plugin                 | Version | Action                 |
+------------------------+---------+------------------------+
| fastlane-plugin-fireb  | 0.3.2   | firebase_app_distribu  |
| ase_app_distribution   |         | tion_login,            |
|                        |         | firebase_app_distribu  |
|                        |         | tion_add_testers,      |
|                        |         | firebase_app_distribu  |
|                        |         | tion_get_udids,        |
|                        |         | firebase_app_distribu  |
|                        |         | tion,                  |
|                        |         | firebase_app_distribu  |
|                        |         | tion_get_latest_relea  |
|                        |         | se,                    |
|                        |         | firebase_app_distribu  |
|                        |         | tion_remove_testers    |
+------------------------+---------+------------------------+

[10:10:20]: ------------------------------
[10:10:20]: --- Step: default_platform ---
[10:10:20]: ------------------------------
[10:10:20]: Driving the lane 'ios sync_development_signing' 🚀
[10:10:20]: --------------------------------
[10:10:20]: --- Step: ensure_bundle_exec ---
[10:10:20]: --------------------------------
[10:10:20]: Using bundled fastlane ✅
[10:10:20]: -------------------
[10:10:20]: --- Step: match ---
[10:10:20]: -------------------
[10:10:20]: Successfully loaded '/Users/markg/Desktop/ios-templates/fastlane/Matchfile' 📄

+--------------+--------------------------------------+
|     Detected Values from './fastlane/Matchfile'     |
+--------------+--------------------------------------+
| git_url      | git@github.com:nimblehq/match-certi  |
|              | ficates.git                          |
| storage_mode | git                                  |
+--------------+--------------------------------------+


+--------------------------------+--------------------------------------+
|                       Summary for match 2.204.3                       |
+--------------------------------+--------------------------------------+
| type                           | development                          |
| app_identifier                 | ["com.example.project.nimble.stagin  |
|                                | g"]                                  |
| readonly                       | true                                 |
| generate_apple_certs           | true                                 |
| skip_provisioning_profiles     | false                                |
| storage_mode                   | git                                  |
| git_url                        | git@github.com:nimblehq/match-certi  |
|                                | ficates.git                          |
| git_branch                     | master                               |
| shallow_clone                  | false                                |
| clone_branch_directly          | false                                |
| keychain_name                  | login.keychain                       |
| force                          | false                                |
| force_for_new_devices          | false                                |
| include_all_certificates       | false                                |
| force_for_new_certificates     | false                                |
| skip_confirmation              | false                                |
| safe_remove_certs              | false                                |
| skip_docs                      | false                                |
| platform                       | ios                                  |
| derive_catalyst_app_identifier | false                                |
| fail_on_name_taken             | false                                |
| skip_certificate_matching      | false                                |
| skip_set_partition_list        | false                                |
| verbose                        | false                                |
+--------------------------------+--------------------------------------+
```

</details>
