### PR TITLE
Add the project's maintainers info

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Team Lead
+* @suho
+
+# Team Members
+* @blyscuit @edgarss @markgravity @minhnimble @nmint8m @phongvhd93 @vnntsu
+
+# Engineering Leads
+CODEOWNERS @nimblehq/engineering-leads


### PR DESCRIPTION
## What happened

Add `CODEOWNERS` in the subdirectory `.github`

## Insight

All project template repositories now have official leads so it is crucial to have it documented. In addition, this will ensure that all concerned developers are notified when new pull requested are created ✌️ 

## Proof Of Work

![image](https://user-images.githubusercontent.com/696529/160563878-bd1b4ed7-5972-440c-ba28-82352a3780a8.png)