### PR TITLE
[#259] Update Bitrise workflow to use Fastlane

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,5 +1,5 @@
 ---
-format_version: '8'
+format_version: '11'
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 project_type: ios
 trigger_map:
@@ -109,7 +109,7 @@ workflows:
     - opts:
         is_expand: false
       BITRISE_SCHEME: {PROJECT_NAME}
-deploy_staging:
+  deploy_staging:
     steps:
     - activate-ssh-key@4:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
@@ -154,10 +154,10 @@ deploy_staging:
     envs:
     - opts:
         is_expand: false
-      BUNDLE_ID: {BUNDLE_ID_STAGING}
+      BUNDLE_ID: BUNDLE_ID_STAGING
     - opts:
         is_expand: false
-      BITRISE_SCHEME: {PROJECT_NAME} Staging
+      BITRISE_SCHEME: PROJECT_NAME Staging
   test:
     steps:
     - activate-ssh-key@4:
@@ -192,15 +192,15 @@ deploy_staging:
     envs:
     - opts:
         is_expand: false
-      BUNDLE_ID: {BUNDLE_ID_STAGING}
+      BUNDLE_ID: BUNDLE_ID_STAGING
     - opts:
         is_expand: false
-      BITRISE_SCHEME: {PROJECT_NAME} Staging
+      BITRISE_SCHEME: PROJECT_NAME Staging
 app:
   envs:
   - opts:
       is_expand: false
-    BITRISE_PROJECT_PATH: {PROJECT_NAME}.xcworkspace
+    BITRISE_PROJECT_PATH: PROJECT_NAME.xcworkspace
   - opts:
       is_expand: false
     TEAM_ID: TEAMID
@@ -209,7 +209,7 @@ app:
     MATCH_REPO_URL: https://github.com/nimblehq/fastlane-match.git
   - opts:
       is_expand: false
-    INFO_PLIST_PATH: "./{PROJECT_NAME}/Info.plist"
+    INFO_PLIST_PATH: "./PROJECT_NAME/Info.plist"
   - opts:
       is_expand: false
-    GOOGLE_SERVICE_INFO_PLIST_PATH: "./{PROJECT_NAME}/GoogleService-Info.plist"
+    GOOGLE_SERVICE_INFO_PLIST_PATH: "./PROJECT_NAME/GoogleService-Info.plist"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -49,12 +49,10 @@ workflows:
     envs:
     - opts:
         is_expand: false
-      BUNDLE_ID:
-        BUNDLE_ID_PRODUCTION:
+      BUNDLE_ID: {BUNDLE_ID_PRODUCTION}
     - opts:
         is_expand: false
-      BITRISE_SCHEME:
-        PROJECT_NAME:
+      BITRISE_SCHEME: {PROJECT_NAME}
   deploy_release_firebase:
     steps:
     - activate-ssh-key@4:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -28,7 +28,7 @@ workflows:
     - git-clone@6.1: {}
     - cache-pull@2: {}
     - cocoapods-install@2: {}
-    - xcode-test@3.0: {}
+    - xcode-test@4.0: {}
     - fastlane-match@0:
         inputs:
         - type: appstore
@@ -36,17 +36,10 @@ workflows:
         - decrypt_password: "$MATCH_PASSWORD"
         - git_url: "$MATCH_REPO_URL"
         - app_id: "$BUNDLE_ID"
-    - certificate-and-profile-installer@1: {}
-    - set-xcode-build-number@1:
+    - fastlane@3:
+        title: Build and upload Production app to App Store
         inputs:
-        - plist_path: "$INFO_PLIST_PATH"
-    - xcode-archive@3:
-        inputs:
-        - export_method: app-store
-    - deploy-to-itunesconnect-application-loader@1.3: {}
-    - firebase-dsym-upload@2:
-        inputs:
-        - fdu_google_services_location: "$GOOGLE_SERVICE_INFO_PLIST_PATH"
+        - lane: build_and_upload_appstore_app
     - cache-push@2:
         inputs:
         - cache_paths: |-
@@ -56,10 +49,12 @@ workflows:
     envs:
     - opts:
         is_expand: false
-      BUNDLE_ID: {BUNDLE_ID_PRODUCTION}
+      BUNDLE_ID:
+        BUNDLE_ID_PRODUCTION:
     - opts:
         is_expand: false
-      BITRISE_SCHEME: {PROJECT_NAME}
+      BITRISE_SCHEME:
+        PROJECT_NAME:
   deploy_release_firebase:
     steps:
     - activate-ssh-key@4:
@@ -76,7 +71,7 @@ workflows:
     - git-clone@6.1: {}
     - cache-pull@2: {}
     - cocoapods-install@2: {}
-    - xcode-test@3.0: {}
+    - xcode-test@4.0: {}
     - fastlane-match@0:
         inputs:
         - type: appstore
@@ -84,18 +79,10 @@ workflows:
         - app_id: "$BUNDLE_ID"
         - git_url: "$MATCH_REPO_URL"
         - decrypt_password: "$MATCH_PASSWORD"
-    - certificate-and-profile-installer@1: {}
-    - set-xcode-build-number@1:
+    - fastlane@3:
+        title: Build and Upload Production App
         inputs:
-        - plist_path: "$INFO_PLIST_PATH"
-    - xcode-archive@3: {}
-    - firebase-app-distribution@0:
-        inputs:
-        - firebase_token: "$FIREBASE_CI_TOKEN"
-        - app: "$FIREBASE_APP_ID_PRD"
-    - firebase-dsym-upload@2:
-        inputs:
-        - fdu_google_services_location: "$GOOGLE_SERVICE_INFO_PLIST_PATH"
+        - lane: build_and_upload_production_app
     - cache-push@2:
         inputs:
         - cache_paths: |-
@@ -125,7 +112,7 @@ workflows:
     - git-clone@6.1: {}
     - cache-pull@2: {}
     - cocoapods-install@2: {}
-    - xcode-test@3.0: {}
+    - xcode-test@4.0: {}
     - fastlane-match@0:
         inputs:
         - type: adhoc
@@ -133,18 +120,10 @@ workflows:
         - app_id: "$BUNDLE_ID"
         - git_url: "$MATCH_REPO_URL"
         - decrypt_password: "$MATCH_PASSWORD"
-    - certificate-and-profile-installer@1: {}
-    - set-xcode-build-number@1:
+    - fastlane@3:
+        title: Build and Upload Staging App
         inputs:
-        - plist_path: "$INFO_PLIST_PATH"
-    - xcode-archive@3: {}
-    - firebase-app-distribution@0:
-        inputs:
-        - firebase_token: "$FIREBASE_CI_TOKEN"
-        - app: "$FIREBASE_APP_ID_STAGING"
-    - firebase-dsym-upload@2:
-        inputs:
-        - fdu_google_services_location: "$GOOGLE_SERVICE_INFO_PLIST_PATH"
+        - lane: build_and_upload_staging_app
     - cache-push@2:
         inputs:
         - cache_paths: |-
@@ -154,10 +133,10 @@ workflows:
     envs:
     - opts:
         is_expand: false
-      BUNDLE_ID: BUNDLE_ID_STAGING
+      BUNDLE_ID: {BUNDLE_ID_STAGING}
     - opts:
         is_expand: false
-      BITRISE_SCHEME: PROJECT_NAME Staging
+      BITRISE_SCHEME: {PROJECT_NAME} Staging
   test:
     steps:
     - activate-ssh-key@4:
@@ -182,7 +161,7 @@ workflows:
         - lane: run_xcov
     - danger@2:
         inputs:
-        - github_api_token: $DANGER_GITHUB_API_TOKEN
+        - github_api_token: "$DANGER_GITHUB_API_TOKEN"
     - cache-push@2:
         inputs:
         - cache_paths: |-
@@ -192,15 +171,15 @@ workflows:
     envs:
     - opts:
         is_expand: false
-      BUNDLE_ID: BUNDLE_ID_STAGING
+      BUNDLE_ID: {BUNDLE_ID_STAGING}
     - opts:
         is_expand: false
-      BITRISE_SCHEME: PROJECT_NAME Staging
+      BITRISE_SCHEME: {PROJECT_NAME} Staging
 app:
   envs:
   - opts:
       is_expand: false
-    BITRISE_PROJECT_PATH: PROJECT_NAME.xcworkspace
+    BITRISE_PROJECT_PATH: {PROJECT_NAME}.xcworkspace
   - opts:
       is_expand: false
     TEAM_ID: TEAMID
@@ -209,7 +188,7 @@ app:
     MATCH_REPO_URL: https://github.com/nimblehq/fastlane-match.git
   - opts:
       is_expand: false
-    INFO_PLIST_PATH: "./PROJECT_NAME/Info.plist"
+    INFO_PLIST_PATH: "./{PROJECT_NAME}/Info.plist"
   - opts:
       is_expand: false
-    GOOGLE_SERVICE_INFO_PLIST_PATH: "./PROJECT_NAME/GoogleService-Info.plist"
+    GOOGLE_SERVICE_INFO_PLIST_PATH: "./{PROJECT_NAME}/GoogleService-Info.plist"


### PR DESCRIPTION
https://github.com/nimblehq/ios-templates/issues/259

## What happened

In the fastfile we're having the following lanes

`build_and_upload_staging_app`
`build_and_upload_production_app`
So we can replace steps `xcode_archive`, `firebase_app_distribution`, `firebase_dsym_upload` with single lane `build_and_upload_staging_app` in `deploy_staging workflow` and `build_and_upload_production_app` in `deploy_release_firebase` workflow
 
## Insight

- Replace Bitrise's readymade steps for build, set build number and upload to AppStore/Firebase with our Fastlane lane
- Fix indentation at `deploy_staging` workflow
 
## Proof Of Work

![Screen Shot 2022-04-14 at 09 47 51](https://user-images.githubusercontent.com/22606906/163304025-e07de6e4-cd95-41bd-83dd-bde11310bb32.png)

[apps_f0f33e48167c2b26_1b703517-4a38-4d9a-b950-6ff83c42b243-full.txt](https://github.com/nimblehq/ios-templates/files/8485881/apps_f0f33e48167c2b26_1b703517-4a38-4d9a-b950-6ff83c42b243-full.txt)

