### PR TITLE
[#227] Add Project Configurations document

### DIFF
--- a/.github/wiki/Project-Configurations.md
+++ b/.github/wiki/Project-Configurations.md
@@ -1,15 +1,15 @@
 ## Project Configurations
 
-This document presents in detail the set of configurations used in the iOS projects developed at Nimble. Included in this document:
+This document presents in detail the set of configurations used in the iOS projects developed at Nimble. Included in this document are:
 
 - Terminologies and topics related to project configurations.
 - Basic targets, schemes, build settings options, etc., for building a project.
 
-### **Targets**
+### Targets
 
 A target specifies a product to build, such as an iOS, watchOS, or macOS app.
 
-When creating a project from a template, a default target will be added automatically for the main application
+When creating a project from a template, a default target will be added automatically for the main application.
 
 There are 3 default targets in a project:
 
@@ -57,7 +57,7 @@ In our iOS template project, there are three custom conditional compilation flag
 | Debug Production | ✔︎ |  | ✔︎ |
 | Release Production |  |  | ✔︎ |
 
-The huge advantage when using custom flags is customizable specific features based on a particular environment.
+The major advantage of custom flags is to allow customizable specific features based on a particular environment.
 
 Example: 
 
@@ -76,7 +76,7 @@ enum Environment {
 }
 ```
 
-During the development process, all functionalities and frameworks are available in the application. However, there can be situations when the developer turns on some features for a particular environment without creating separate modules for the application. In these cases, taking advantage of `Active Compilation Conditions` by declaring a condition to include or exclude code is the recommended solution.
+During the development process, all functionalities and frameworks are available in the application. However, there can be situations when the developers just want to turn on some features for a particular environment without creating separate modules for the application. In these cases, declaring a condition to include or exclude code using `Active Compilation Conditions` is the recommended solution.
 
 ```swift
 #if DEBUG
@@ -86,15 +86,15 @@ During the development process, all functionalities and frameworks are available
 #endif
 ```
 
-### Xcode Configuration **File**
+### Xcode Configuration File
 
-A Configuration Settings File (`*.xcconfig`), also known as a build configuration file, is a plain text file that defines and overrides the build settings for a particular build configuration of a project or target. This type of file can be edited outside of Xcode and integrates well with source control systems.
+A Configuration Settings File (`*.xcconfig`), also known as a build configuration file, is a plain text file that defines and overrides the default build settings for a particular build configuration of a project or target. This type of file can be edited outside of Xcode and integrates well with source control systems.
 
 Because of different settings for each environment (such as bundle identifiers, endpoints, etc.), the developers also define them in different *.xcconfig files.
 
-### **Settings Bundle**
+### Settings Bundle
 
-To support multiple levels of testing, the `Settings Bundle` is usually integrated along with the dev configurations. In addition, the Settings Bundle facilitates the testing process. It creates a shortcut to change environment values without using any third-party API or server.
+To support multiple levels of testing, the `Settings Bundle` is usually integrated along with the dev configurations (a **.plist** file). In addition, the Settings Bundle facilitates the testing process. It creates a shortcut to change environment values without using any third-party API or server.
 
 Settings Bundle works well when developing:
 
@@ -109,7 +109,7 @@ The Settings Bundle is only enabled on Dev environments. It is optional for Beta
 
 Basically, the debug Symbol file (`dSYM` file) is used to de-obfuscate stack traces from crashes happening on the production app. The dSYM files store the debug symbols for the application. Then services (like Crashlytics) use the dSYM files to replace the symbols in the crash reports with the originating locations in the source code. Hence, the crash reports will be more readable and understandable.
 
-Go to **Build Setting** → **Debug Information Format**. The debug symbols with a dSYM file (DWARF with dSYM file) are enabled for the release build by default.
+Go to **Build Settings** → **Debug Information Format**. The debug symbols with a dSYM file (DWARF with dSYM file) are enabled for the release build by default.
 
 A benefit of using the dSYM is reducing the binary size when building an application. Read more about it in the technical note [TN2151](https://developer.apple.com/library/archive/technotes/tn2151/_index.html).
 
@@ -122,7 +122,7 @@ Only include the dSYM file for release builds.
 | Debug Production |  |
 | Release Production | ✔︎ |
 
-### **Enable Bitcode**
+### Enable Bitcode
 
 Bitcode is a technology that enables recompiling applications to reduce their size. The recompilation happens when the application is uploaded to the App Store Connect or exported for Ad Hoc, Development, or Enterprise distribution.
 

--- a/.github/wiki/Project-Configurations.md
+++ b/.github/wiki/Project-Configurations.md
@@ -1,0 +1,136 @@
+## Project Configurations
+
+This document presents in detail the set of configurations used in the iOS projects developed at Nimble. Included in this document:
+
+- Terminologies and topics related to project configurations.
+- Basic targets, schemes, build settings options, etc., for building a project.
+
+### **Targets**
+
+A target specifies a product to build, such as an iOS, watchOS, or macOS app.
+
+When creating a project from a template, a default target will be added automatically for the main application
+
+There are 3 default targets in a project:
+
+- {ProjectName}
+- {ProjectName}Tests
+- {ProjectName}UITests
+
+### Schemes
+
+A scheme is a collection of settings that specifies the targets to build for a project, the build configuration to use, and the executable environment to use when the product is launched.
+
+The 2 main schemes in a project:
+
+- {ProjectName}
+- {ProjectName} Staging
+
+### Build Configurations in Schemes
+
+It is possible to build a scheme with different Build Configurations. Initially, there are 2 basic configurations for a project generated automatically by Xcode, which are:
+
+- Debug
+- Release
+
+However, these basic configurations are not enough for our development process. Since our team always wants to ensure the application is working in a designated manner, additional levels of testing are required before the application is ready to be used.
+
+The recommended set of configurations to have is:
+
+- Debug Staging
+- Release Staging
+- Debug Production
+- Release Production
+
+### Active Compilation Conditions
+
+Having distinct flags for each configuration is the preferred solution.
+
+Xcode provides a build setting named `Active Compilation Conditions`, which supports passing conditional compilation flags to the Swift compiler.
+
+In our iOS template project, there are three custom conditional compilation flags: `DEBUG`, `STAGING`, `PRODUCTION`. The following table will describe how the developers differentiate a configuration from the others.
+
+| Build Configurations | DEBUG | STAGING | PRODUCTION |
+|---|---|---|---|
+| Debug Staging | ✔︎ | ✔︎ |  |
+| Release Staging |  | ✔︎ |  |
+| Debug Production | ✔︎ |  | ✔︎ |
+| Release Production |  |  | ✔︎ |
+
+The huge advantage when using custom flags is customizable specific features based on a particular environment.
+
+Example: 
+
+Specify a value based on the environment:
+
+```swift
+enum Environment {
+
+    static func based<T>(staging: T, production: T) -> T {
+        #if PRODUCTION
+        return production
+        #else
+        return staging
+        #endif
+	}
+}
+```
+
+During the development process, all functionalities and frameworks are available in the application. However, there can be situations when the developer turns on some features for a particular environment without creating separate modules for the application. In these cases, taking advantage of `Active Compilation Conditions` by declaring a condition to include or exclude code is the recommended solution.
+
+```swift
+#if DEBUG
+    // Code the app includes in DEBUG environments
+#else
+    // Code the app includes when it is not build with DEBUG environments
+#endif
+```
+
+### Xcode Configuration **File**
+
+A Configuration Settings File (`*.xcconfig`), also known as a build configuration file, is a plain text file that defines and overrides the build settings for a particular build configuration of a project or target. This type of file can be edited outside of Xcode and integrates well with source control systems.
+
+Because of different settings for each environment (such as bundle identifiers, endpoints, etc.), the developers also define them in different *.xcconfig files.
+
+### **Settings Bundle**
+
+To support multiple levels of testing, the `Settings Bundle` is usually integrated along with the dev configurations. In addition, the Settings Bundle facilitates the testing process. It creates a shortcut to change environment values without using any third-party API or server.
+
+Settings Bundle works well when developing:
+
+- [Feature toggle](https://martinfowler.com/articles/feature-toggles.html)
+- [A/B Testing](https://en.wikipedia.org/wiki/A/B_testing)
+- Change API endpoints for testing the application with multiple servers
+- Define a list of prefilled credentials and a toggle for prefilling
+
+The Settings Bundle is only enabled on Dev environments. It is optional for Beta environments.
+
+### Debug Symbol File
+
+Basically, the debug Symbol file (`dSYM` file) is used to de-obfuscate stack traces from crashes happening on the production app. The dSYM files store the debug symbols for the application. Then services (like Crashlytics) use the dSYM files to replace the symbols in the crash reports with the originating locations in the source code. Hence, the crash reports will be more readable and understandable.
+
+Go to **Build Setting** → **Debug Information Format**. The debug symbols with a dSYM file (DWARF with dSYM file) are enabled for the release build by default.
+
+A benefit of using the dSYM is reducing the binary size when building an application. Read more about it in the technical note [TN2151](https://developer.apple.com/library/archive/technotes/tn2151/_index.html).
+
+Only include the dSYM file for release builds.
+
+| Build Configurations | Included dSYM file |
+|---|---|
+| Debug Staging |  |
+| Release Staging | ✔︎ |
+| Debug Production |  |
+| Release Production | ✔︎ |
+
+### **Enable Bitcode**
+
+Bitcode is a technology that enables recompiling applications to reduce their size. The recompilation happens when the application is uploaded to the App Store Connect or exported for Ad Hoc, Development, or Enterprise distribution.
+
+Enable build with bitcode for Production only.
+
+| Build configurations | Enable Bitcode |
+|---|---|
+| Debug Staging |  |
+| Release Staging |  |
+| Debug Production |  |
+| Release Production | ✔︎ |

--- a/.github/wiki/Standard-File-Organization.md
+++ b/.github/wiki/Standard-File-Organization.md
@@ -126,7 +126,7 @@ To keep all current and upcoming iOS projects aligned, we standardize an iOS pro
             └── TestError.swift
 ```
 
-## **README.md**
+## README.md
 
 `README.md` introduces the overview of the project, for example:
 

--- a/.github/wiki/_Sidebar.md
+++ b/.github/wiki/_Sidebar.md
@@ -4,5 +4,6 @@
 
 **Technical document**
 * [[Standard File Organization]]
+* [[Project Configurations]]
 * [[Project Dependencies]]
 * [[Self Hosted Github Actions]]


### PR DESCRIPTION
Resolve #227 

## What happened

As we have a workflow that supports publishing docs to the wiki, we need to bring all iOS templates' documents into the repository's source.
 
## Insight

- Add document into the folder wiki

- Brings document from [the Notion page](https://www.notion.so/nimblehq/Project-Configurations-e66e3e19ecc541028c605481b28b1bd0) into the repository's source
 
## Proof Of Work

![Screen Shot 2022-05-05 at 17 30 55](https://user-images.githubusercontent.com/19943832/166906229-3abb1597-57c1-4b66-be3f-d8eb1a995482.png)
