### PR TITLE
[#269] Fix: Version of Sourcery

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -7,7 +7,9 @@ def testing_pods
   pod 'Nimble'
   pod 'RxNimble', subspecs: ['RxBlocking', 'RxTest']
   pod 'RxSwift'
-  pod 'Sourcery'
+  # TODO: Remove or update the version of `1.8.0` to the newest version (not 1.8.1) when init a new project.
+  # Currently, there is a bug on `1.8.1` - the newest version.
+  pod 'Sourcery', '1.8.0'
   pod 'SwiftFormat/CLI'
 end
 


### PR DESCRIPTION
Resolves #269 

## What happened

With the Sourcery version 1.8.1, we can't install it on CI.
 
## Insight

- Specific the version of Sourcery to `1.8.0`

## Proof Of Work

to be provided
