### PR TITLE
[#275] Fix: Package name contains "-" symbol is invalid while running install script

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -80,7 +80,7 @@ if [ -z "$bundle_id_production" ] || [ -z "$bundle_id_staging" ] || [ -z "$proje
 fi
 
 # Enforce package name
-regex='^[a-z][a-z0-9_]*(\.[a-z0-9_]+)+[0-9a-z_]$'
+regex='^[a-z][a-z0-9_]*(\.[a-z0-9_-]+)+[0-9a-z_-]$'
 if ! [[ $bundle_id_production =~ $regex ]]; then
     die "Invalid Package Name: $bundle_id_production (needs to follow standard pattern {com.example.package})"
 fi


### PR DESCRIPTION
https://github.com/nimblehq/ios-templates/issues/275

## What happened

Install script currently does not accept "-" symbol inside the package name. We must update regex to allow that case.
 
## Insight

Update regex for package name validation
 
## Proof Of Work

<img width="795" alt="Screen Shot 2022-05-24 at 15 11 28" src="https://user-images.githubusercontent.com/24598204/169982682-428e1e41-e28f-449c-9f6c-e829d26a1fe6.png">

