### PR TITLE
[#284] Add trigger when `main` branch is updated

### DIFF
--- a/.github/wiki/Bitrise.md
+++ b/.github/wiki/Bitrise.md
@@ -21,7 +21,7 @@ Out of the box, the Bitrise Template has the following workflows and steps:
 | test                    | Create or Update a PR   |
 | deploy_staging          | Push branch `develop`   |
 | deploy_release_firebase | Push branch `release/*` |
-| deploy_app_store        | Push branch `master`    |
+| deploy_app_store        | Push branch `master`/`main`    |
 
 ## Environment and Secrets
 ### App Environtment Variables
@@ -39,6 +39,9 @@ All four workflows have their own variables:
 
 - BUNDLE_ID
 > e.g., com.nimblehq.exampleApp
+
+- BITRISE_SCHEME
+> Your build scheme in Xcode (e.g., ExampleApp UAT, ExampleApp Staging, or ExampleApp)
 
 *Depending on which workflow, the value of those variables may differ from other workflows.*
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -7,6 +7,8 @@ trigger_map:
   workflow: deploy_staging
 - push_branch: master
   workflow: deploy_app_store
+- push_branch: main
+  workflow: deploy_app_store
 - push_branch: release
   workflow: deploy_release_firebase
 - push_branch: "*"
@@ -184,9 +186,3 @@ app:
   - opts:
       is_expand: false
     MATCH_REPO_URL: https://github.com/nimblehq/fastlane-match.git
-  - opts:
-      is_expand: false
-    INFO_PLIST_PATH: "./{PROJECT_NAME}/Info.plist"
-  - opts:
-      is_expand: false
-    GOOGLE_SERVICE_INFO_PLIST_PATH: "./{PROJECT_NAME}/GoogleService-Info.plist"


### PR DESCRIPTION
https://github.com/nimblehq/ios-templates/issues/284

## What happened

Currently, the deploy workflow from Bitrise templates is triggered only for the master branch, we need to support the main branch also.
 
## Insight

- Add a new trigger that will run the `deploy_app_store` workflow when `main` branch is updated.
- Update the Bitrise template document to reflect the change on the trigger map.
 
## Proof Of Work

![Screen Shot 2022-06-01 at 11 17 06](https://user-images.githubusercontent.com/22606906/171326795-6e752f3c-3e79-4df2-8131-06ccb5fd3c3b.png)

