### PR TITLE
[#293] [Bug] Fix: There is no lane name run_xcov in Fastfile

### DIFF
--- a/.github/wiki/Bitrise.md
+++ b/.github/wiki/Bitrise.md
@@ -11,8 +11,8 @@ Out of the box, the Bitrise Template has the following workflows and steps:
 | Bitrise.io Cache:Pull     | Bitrise.io Cache:Pull                                   | Bitrise.io Cache:Pull                   | Bitrise.io Cache:Pull                     |
 | Run CocoaPods install     | Run CocoaPods install                                   | Run CocoaPods install                   | Run CocoaPods install                     |
 | Fastlane - Build and Test | Xcode Test for iOS                                      | Xcode Test for iOS                      | Xcode Test for iOS                        |
-| Fastlane - Run XCov       | Fastlane Match                                          | Fastlane Match                          | Fastlane Match                            |
-| Danger                    | Fastlane - Build and Upload Production App to App Store | Fastlane - Build and Upload Staging App | Fastlane: Build and Upload Production App |
+| Danger                    | Fastlane Match                                          | Fastlane Match                          | Fastlane Match                            |
+|                           | Fastlane - Build and Upload Production App to App Store | Fastlane - Build and Upload Staging App | Fastlane: Build and Upload Production App |
 
 ## Trigger Map
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -156,9 +156,6 @@ workflows:
     - fastlane@3:
         inputs:
         - lane: build_and_test
-    - fastlane@3:
-        inputs:
-        - lane: run_xcov
     - danger@2:
         inputs:
         - github_api_token: "$DANGER_GITHUB_API_TOKEN"


### PR DESCRIPTION
https://github.com/nimblehq/ios-templates/issues/293

## What happened

Currently, the lane run_xcov does not exist in Fastfile. It was removed in PR https://github.com/nimblehq/ios-templates/pull/242. So we should remove where the lane run_xcov is used.
 
## Insight

In this PR, I removed where the lane `run_xcov` is used in `bitrise.yml` and `Bitrise.md`.
