### PR TITLE
[#296] [Bug] Fix: Add step to clean up previous code coverage report into bitrise.yml 

### DIFF
--- a/.github/wiki/Bitrise.md
+++ b/.github/wiki/Bitrise.md
@@ -11,8 +11,8 @@ Out of the box, the Bitrise Template has the following workflows and steps:
 | Bitrise.io Cache:Pull     | Bitrise.io Cache:Pull                                   | Bitrise.io Cache:Pull                   | Bitrise.io Cache:Pull                     |
 | Run CocoaPods install     | Run CocoaPods install                                   | Run CocoaPods install                   | Run CocoaPods install                     |
 | Fastlane - Build and Test | Xcode Test for iOS                                      | Xcode Test for iOS                      | Xcode Test for iOS                        |
-| Danger                    | Fastlane Match                                          | Fastlane Match                          | Fastlane Match                            |
-|                           | Fastlane - Build and Upload Production App to App Store | Fastlane - Build and Upload Staging App | Fastlane: Build and Upload Production App |
+| Fastlane - Clean Up Xcov  | Fastlane Match                                          | Fastlane Match                          | Fastlane Match                            |
+| Danger                    | Fastlane - Build and Upload Production App to App Store | Fastlane - Build and Upload Staging App | Fastlane: Build and Upload Production App |
 
 ## Trigger Map
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -156,6 +156,9 @@ workflows:
     - fastlane@3:
         inputs:
         - lane: build_and_test
+    - fastlane@3:
+        inputs:
+        - lane: clean_up_xcov
     - danger@2:
         inputs:
         - github_api_token: "$DANGER_GITHUB_API_TOKEN"


### PR DESCRIPTION
https://github.com/nimblehq/ios-templates/issues/296

## What happened

According to [this comment](https://github.com/nimblehq/ios-templates/pull/295#discussion_r895304282), we should add a step to clean up previous code coverage report into `bitrise.yml` to keep the consistency between the Bitrise and Github Action workflows.
 
## Proof Of Work

N/A
