### PR TITLE
[#286] [Bug] Fix: The trigger setup for the publish docs to wiki workflow

### DIFF
--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -3,7 +3,7 @@ name: Publish docs to Wiki
 on:
   push:
     paths:
-      - docs/**
+      - .github/wiki/**
     branches:
       - main
       - master


### PR DESCRIPTION
https://github.com/nimblehq/ios-templates/issues/286

## What happened

The publish docs to wiki workflow is triggered on push with the path docs/**, however, we changed the path to .github/wiki, we need to update that
 
## Proof Of Work

N/A