### PR TITLE
[#290] [Chore] Update Github Wiki following the convention

### DIFF
--- a/.github/wiki/_Sidebar.md
+++ b/.github/wiki/_Sidebar.md
@@ -5,11 +5,12 @@
 
 ## Architecture
 
-## Infrastructure
-
 - [[Standard File Organization]]
 - [[Project Configurations]]
 - [[Project Dependencies]]
+
+## Infrastructure
+
 - [[Github Actions]]
 - [[Self Hosted Github Actions]]
 - [[Bitrise]]


### PR DESCRIPTION
https://github.com/nimblehq/ios-templates/issues/290

## What happened

It needs to update the wiki of ios-template, following [Nimble's Github Wiki convention](https://nimblehq.co/compass/development/documentation/github-wiki/).
 
## Insight

In this PR: 

- I move the following documents from  the `Infrastructure` section into the `Architecture` section, according to [this comment](https://github.com/nimblehq/ios-templates/commit/49e4b39f8a195e5004117372cb54f85676a2524f#commitcomment-76307423):
  - Standard File Organization
  - Project Configurations
  - Project Dependencies
 
## Proof Of Work

N/A
