### PR TITLE
[#312] Run `xcode_summary` on changed files only in Danger

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -26,6 +26,14 @@ swiftlint.lint_files(
 xcresultPath = "#{Constants.TEST_OUTPUT_DIRECTORY_PATH}/#{Constants.TESTS_SCHEME}.xcresult"
 
 # Xcode summary
+changed_files = (git.modified_files - git.deleted_files) + git.added_files
+xcode_summary.ignored_results { |result|
+  if result.location
+    not changed_files.include?(result.location.file_path)
+  else
+    true
+  end
+}
 xcode_summary.ignored_files = 'Pods/**'
 xcode_summary.inline_mode = true
 xcode_summary.report xcresultPath


### PR DESCRIPTION
https://github.com/nimblehq/ios-templates/issues/312

## What happened

Currently, we are running `xcode_summary` on whole the file in the project which could lead to repeat warnings on every PR, and that makes it hard for the reviewer to focus on the new warnings produced by changed files. There is a solution for this case that we can use `xcode_summary.ignored_results` to specify which result can be ignored, in our case they are unchanged files.

## Insight

The following code is added to the `Xcode Summary` section in the Danger file for ignoring changed files:
```
changed_files = (git.modified_files - git.deleted_files) + git.added_files
xcode_summary.ignored_results { |result|
  if result.location
    not changed_files.include?(result.location.file_path)
  else
    true
  end
}
```
 
## Proof Of Work

Only changed file is reported and notified:

|Without changed files filter for `xcode_summary`|With changed files filter for `xcode_summary`|
|----------------------------------------------------|----------------------------------------------------|
|![Screen Shot 2022-08-08 at 18 25 55](https://user-images.githubusercontent.com/70877098/183408261-b8c78495-547a-460a-965d-1afd2e6ffe13.png)|![Screen Shot 2022-08-08 at 16 42 37](https://user-images.githubusercontent.com/70877098/183389567-9be07f7d-c0fb-4f73-91e8-64d84e7b96fe.png)|

FYI, this is the [PR](https://github.com/nimblehq/nimble-medium-ios/pull/284) in `nimble-medium-ios` repository used for testing.
