### PR TITLE
Add `workflow_dispatch` to manually trigger deploy workflows

### DIFF
--- a/.github/workflows/deploy_AppStore.yml
+++ b/.github/workflows/deploy_AppStore.yml
@@ -8,6 +8,7 @@ name: Deploy Build To App Store
 on:
   push:
     branches: [ master, main ]
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/.github/workflows/deploy_Firebase.yml
+++ b/.github/workflows/deploy_Firebase.yml
@@ -8,6 +8,7 @@ name: Deploy Build To Firebase
 on:
   push:
     branches: [ develop ]
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/.github/workflows/deploy_Release_Firebase.yml
+++ b/.github/workflows/deploy_Release_Firebase.yml
@@ -8,6 +8,7 @@ name: Deploy Release Build To Firebase
 on:
   push:
     branches: [ release/** ]
+  workflow_dispatch:
 
 jobs:
   Lint:


### PR DESCRIPTION
Resolves #288 

## What happened

Add `workflow_dispatch` to manually trigger deploy workflows.
 
## Insight

Here is `workflow_dispatch` documentation: 
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
- https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow

NOTE: To trigger the workflow_dispatch event, your workflow must be in the default branch
 
## Proof Of Work

`N/A`


