### PR TITLE
[#322] Add Multiline Parameter Lint

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -11,3 +11,7 @@
 --disable blankLinesAtStartOfScope
 --stripunusedargs closure-only
 --extensionacl on-declarations
+--wraparguments before-first
+--wrapparameters before-first
+--wrapcollections before-first
+--maxwidth 120

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -106,3 +106,15 @@ implicit_return:
   included:
     - closure
     - getter
+
+custom_rules:
+  multiline_collection_one_per_line:
+    name: 'Multiline Collection One Per Line'
+    message: 'Collection should be either on the same line, or one per line.'
+    regex: '\[\n([^\[\(])*(,([^\n\r])*[\w]+)([^\[])*\n(\s)*]'
+    severity: warning
+  multiline_arguments_one_per_line:
+    name: 'Multiline Arguments One Per Line'
+    message: 'Arguments should be either on the same line, or one per line.'
+    regex: '[^\n\r]\(\n([^\(])*([^\n\r],([^\n\r])*[\w]+)([^\)])*\n(\s)*\)'
+    severity: warning


### PR DESCRIPTION

https://github.com/nimblehq/ios-templates/issues/322

## What happened

Add SwiftLint rules to check for multiline arguments.

Add SwiftFormat rules to format code blocks.
 
## Insight

**Known bug**:
If array has init with multiple arguments, lint will not be able to catch it.
```
[
Item("a", "b"), Item("A", "b), // lint will not be able to catch this one.
Item("a", "c")
]
```
 
## Proof Of Work
<img width="1512" alt="Screen Shot 2565-08-18 at 14 11 43" src="https://user-images.githubusercontent.com/6356137/185343003-eca27996-b9aa-46d1-9342-7aa47d090695.png">
<img width="1512" alt="Screen Shot 2565-08-18 at 14 11 47" src="https://user-images.githubusercontent.com/6356137/185343044-142bd122-217d-432d-a2d5-5275fdc37c7a.png">
<img width="1512" alt="Screen Shot 2565-08-18 at 14 11 51" src="https://user-images.githubusercontent.com/6356137/185343051-7b86ac8a-95e8-41af-87ab-7def34a7f464.png">

https://user-images.githubusercontent.com/6356137/185343080-4bab077a-493f-476b-af85-36f65f7cc848.mov



