### PR TITLE
[#301] [Fix] Constants.DEV_PORTAL_APPLE_ID is unused by mistake

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -34,7 +34,8 @@ match_manager = MatchManager.new(
   fastlane: self,
   keychain_name: Constants.KEYCHAIN_NAME,
   keychain_password: Constants.KEYCHAIN_PASSWORD,
-  is_ci: Environments.CI
+  is_ci: Environments.CI,
+  username: DeliverableConstants.DEV_PORTAL_APPLE_ID
 )
 
 before_all do
@@ -88,7 +89,10 @@ platform :ios do
     device_udid = prompt(text: 'Enter the device UDID: ')
     device_hash = {}
     device_hash[device_name] = device_udid
-    register_devices(devices: device_hash)
+    register_devices(
+      devices: device_hash,
+      username: DeliverableConstants.DEV_PORTAL_APPLE_ID
+    )
 
     match_manager.sync_development_signing(app_identifier: nil, force: true)
     match_manager.sync_adhoc_signing(app_identifier: nil, force: true)

--- a/fastlane/Managers/MatchManager.rb
+++ b/fastlane/Managers/MatchManager.rb
@@ -5,12 +5,14 @@ class MatchManager
       fastlane:,
       keychain_name:,
       keychain_password:,
-      is_ci:
+      is_ci:,
+      username:
   )
     @fastlane = fastlane
     @keychain_name = keychain_name
     @keychain_password = keychain_password
     @is_ci = is_ci
+    @username = username
   end
 
   def sync_development_signing(app_identifier:, force: false)
@@ -22,7 +24,8 @@ class MatchManager
         keychain_password: @keychain_password,
         app_identifier: app_identifier,
         readonly: !force,
-        force: force
+        force: force,
+        username: @username
       )
     else
       @fastlane.match(type: 'development', app_identifier: app_identifier, readonly: !force, force: force)
@@ -38,7 +41,8 @@ class MatchManager
         keychain_password: @keychain_password,
         app_identifier: app_identifier,
         readonly: !force,
-        force: force
+        force: force,
+        username: @username
       )
     else
       @fastlane.match(type: 'adhoc', app_identifier: app_identifier, readonly: !force, force: force)
@@ -53,7 +57,8 @@ class MatchManager
         keychain_name: @keychain_name,
         keychain_password: @keychain_password,
         app_identifier: app_identifier,
-        readonly: true
+        readonly: true,
+        username: @username
       )
     else
       @fastlane.match(type: 'appstore', app_identifier: app_identifier, readonly: true)

--- a/fastlane/Managers/MatchManager.rb
+++ b/fastlane/Managers/MatchManager.rb
@@ -24,11 +24,16 @@ class MatchManager
         keychain_password: @keychain_password,
         app_identifier: app_identifier,
         readonly: !force,
+        force: force
+      )
+    else
+      @fastlane.match(
+        type: 'development',
+        app_identifier: app_identifier,
+        readonly: !force,
         force: force,
         username: @username
       )
-    else
-      @fastlane.match(type: 'development', app_identifier: app_identifier, readonly: !force, force: force)
     end
   end
 
@@ -41,11 +46,16 @@ class MatchManager
         keychain_password: @keychain_password,
         app_identifier: app_identifier,
         readonly: !force,
+        force: force
+      )
+    else
+      @fastlane.match(
+        type: 'adhoc',
+        app_identifier: app_identifier,
+        readonly: !force,
         force: force,
         username: @username
       )
-    else
-      @fastlane.match(type: 'adhoc', app_identifier: app_identifier, readonly: !force, force: force)
     end
   end
 
@@ -57,11 +67,15 @@ class MatchManager
         keychain_name: @keychain_name,
         keychain_password: @keychain_password,
         app_identifier: app_identifier,
+        readonly: true
+      )
+    else
+      @fastlane.match(
+        type: 'appstore',
+        app_identifier: app_identifier,
         readonly: true,
         username: @username
       )
-    else
-      @fastlane.match(type: 'appstore', app_identifier: app_identifier, readonly: true)
     end
   end
 


### PR DESCRIPTION
https://github.com/nimblehq/ios-templates/issues/301

## What happened

- Pass `DeliverableConstants.DEV_PORTAL_APPLE_ID` to `MatchManager` and `register_new_device` lane
 
## Insight

n/a
 
## Proof Of Work

![Screen Shot 2022-08-19 at 13 48 04](https://user-images.githubusercontent.com/17875522/185560806-deecf145-fa65-4afe-a8c9-d1deb135b8af.png)

