### PR TITLE
[#333] As a developer, I can build the project with the adhoc and appstore methods with Fastlane Swift

### DIFF
--- a/fastlane/Constants/Constant.swift
+++ b/fastlane/Constants/Constant.swift
@@ -8,8 +8,21 @@
 
 enum Constant {
 
+    // MARK: - Match
+
     static let userName: String = "<#userName#>"
     static let teamId: String = "<#teamId#>"
     static let keychainName: String = "<#keychainName#>"
     static let matchURL: String = "<#matchURL#>"
+
+    // MARK: - Project
+
+    static let bundleId = "<#bundleId#>"
+    static let productName: String = "<#productName#>"
+    static let scheme: String = "<#scheme#>"
+
+    // MARK: - Path
+
+    static let derivedDataPath = "./DerivedData"
+    static let buildPath = "./Build"
 }

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -19,12 +19,12 @@ class Fastfile: LaneFile {
 
     func buildAdHocStagingLane() {
         desc("Build ad-hoc staging")
-        Build.adHoc(env: .staging)
+        Build.adHoc(environment: .staging)
     }
 
     func buildAdHocProductionLane() {
         desc("Build ad-hoc production")
-        Build.adHoc(env: .production)
+        Build.adHoc(environment: .production)
     }
 
     func buildAppStoreLane() {

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -16,4 +16,19 @@ class Fastfile: LaneFile {
         Match.syncCodeSigning(type: .adHoc, appIdentifier: ["co.nimblehq.ios.templates"])
         Match.syncCodeSigning(type: .appStore, appIdentifier: ["co.nimblehq.ios.templates"])
     }
+
+    func buildAdHocStagingLane() {
+        desc("Build ad-hoc staging")
+        Build.adHoc(env: .staging)
+    }
+
+    func buildAdHocProductionLane() {
+        desc("Build ad-hoc production")
+        Build.adHoc(env: .production)
+    }
+
+    func buildAppStoreLane() {
+        desc("Build app store")
+        Build.appStore()
+    }
 }

--- a/fastlane/Helpers/Build.swift
+++ b/fastlane/Helpers/Build.swift
@@ -1,0 +1,82 @@
+//
+//  Build.swift
+//  FastlaneRunner
+//
+//  Created by Su T. on 23/09/2022.
+//  Copyright © 2022 Nimble. All rights reserved.
+//
+
+final class Build {
+
+    static func adHoc(env: Environment) {
+        build(env: env, type: .adHoc)
+    }
+
+    static func appStore() {
+        build(env: .production, type: .appStore)
+    }
+
+    static private func build(
+        env: Environment,
+        type: BuildType
+    ) {
+        buildApp(
+            scheme: .userDefined(env.scheme),
+            clean: .userDefined(true),
+            outputName: .userDefined(env.productName),
+            includeSymbols: .userDefined(true),
+            includeBitcode: .userDefined(type == .appStore),
+            exportMethod: .userDefined(type.value),
+            exportOptions: .userDefined([
+                // NOTE: bundleId should be `env.bundleId` instead of `Constant.bundleId`
+                // To test ios-template, uncomment right below
+//                Constant.bundleId: "match \(type.method) \(Constant.bundleId)"
+                env.bundleId: "match \(type.method) \(env.bundleId)"
+            ]),
+            buildPath: .userDefined(Constant.buildPath),
+            derivedDataPath: .userDefined(Constant.derivedDataPath),
+            xcodebuildFormatter: "xcpretty" // Default `xcbeautify` will never work
+        )
+    }
+}
+
+extension Build {
+
+    enum Environment: String {
+
+        case staging = "Staging"
+        case production = ""
+
+        var productName: String { "\(Constant.productName) \(rawValue)".trimmed }
+
+        var scheme: String { "\(Constant.scheme) \(rawValue)".trimmed }
+
+        var bundleId: String {
+            let bundleId = Constant.bundleId
+            switch self {
+            case .staging: return "\(Constant.bundleId).\(rawValue.lowercased())"
+            case .production: return bundleId
+            }
+        }
+    }
+
+    private enum BuildType: String {
+
+        case adHoc = "ad-hoc"
+        case appStore = "app-store"
+
+        var value: String { return rawValue }
+
+        var method: String {
+            switch self {
+            case .adHoc: return "AdHoc"
+            case .appStore: return "AppStore"
+            }
+        }
+    }
+}
+
+extension String {
+
+    fileprivate var trimmed: String { trimmingCharacters(in: .whitespacesAndNewlines) }
+}

--- a/fastlane/Helpers/Build.swift
+++ b/fastlane/Helpers/Build.swift
@@ -8,22 +8,22 @@
 
 final class Build {
 
-    static func adHoc(env: Environment) {
-        build(env: env, type: .adHoc)
+    static func adHoc(environment: Environment) {
+        build(environment: environment, type: .adHoc)
     }
 
     static func appStore() {
-        build(env: .production, type: .appStore)
+        build(environment: .production, type: .appStore)
     }
 
     static private func build(
-        env: Environment,
+        environment: Environment,
         type: BuildType
     ) {
         buildApp(
-            scheme: .userDefined(env.scheme),
+            scheme: .userDefined(environment.scheme),
             clean: .userDefined(true),
-            outputName: .userDefined(env.productName),
+            outputName: .userDefined(environment.productName),
             includeSymbols: .userDefined(true),
             includeBitcode: .userDefined(type == .appStore),
             exportMethod: .userDefined(type.value),
@@ -31,7 +31,7 @@ final class Build {
                 // NOTE: bundleId should be `env.bundleId` instead of `Constant.bundleId`
                 // To test ios-template, uncomment right below
 //                Constant.bundleId: "match \(type.method) \(Constant.bundleId)"
-                env.bundleId: "match \(type.method) \(env.bundleId)"
+                environment.bundleId: "match \(type.method) \(environment.bundleId)"
             ]),
             buildPath: .userDefined(Constant.buildPath),
             derivedDataPath: .userDefined(Constant.derivedDataPath),

--- a/fastlane/swift/FastlaneSwiftRunner/FastlaneSwiftRunner.xcodeproj/project.pbxproj
+++ b/fastlane/swift/FastlaneSwiftRunner/FastlaneSwiftRunner.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		8B92CD0728DC638800A3FF05 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B92CD0628DC638800A3FF05 /* Constant.swift */; };
 		8B92CD0928DC63A700A3FF05 /* Secret.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B92CD0828DC63A700A3FF05 /* Secret.swift */; };
 		8B92CD0B28DC63E000A3FF05 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B92CD0A28DC63E000A3FF05 /* Keychain.swift */; };
+		90C4D77B28DDC86800E06274 /* Build.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C4D77A28DDC86800E06274 /* Build.swift */; };
 		B302067B1F5E3E9000DE6EBD /* SnapshotfileProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30206741F5E3E9000DE6EBD /* SnapshotfileProtocol.swift */; };
 		B302067C1F5E3E9000DE6EBD /* GymfileProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30206751F5E3E9000DE6EBD /* GymfileProtocol.swift */; };
 		B302067D1F5E3E9000DE6EBD /* MatchfileProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30206761F5E3E9000DE6EBD /* MatchfileProtocol.swift */; };
@@ -69,6 +70,7 @@
 		8B92CD0628DC638800A3FF05 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Constant.swift; path = ../../Constants/Constant.swift; sourceTree = "<group>"; };
 		8B92CD0828DC63A700A3FF05 /* Secret.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Secret.swift; path = ../../Constants/Secret.swift; sourceTree = "<group>"; };
 		8B92CD0A28DC63E000A3FF05 /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Keychain.swift; path = ../../Helpers/Keychain.swift; sourceTree = "<group>"; };
+		90C4D77A28DDC86800E06274 /* Build.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Build.swift; path = ../../Helpers/Build.swift; sourceTree = "<group>"; };
 		B30206741F5E3E9000DE6EBD /* SnapshotfileProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SnapshotfileProtocol.swift; path = ../SnapshotfileProtocol.swift; sourceTree = "<group>"; };
 		B30206751F5E3E9000DE6EBD /* GymfileProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GymfileProtocol.swift; path = ../GymfileProtocol.swift; sourceTree = "<group>"; };
 		B30206761F5E3E9000DE6EBD /* MatchfileProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MatchfileProtocol.swift; path = ../MatchfileProtocol.swift; sourceTree = "<group>"; };
@@ -117,8 +119,9 @@
 		8B92CD0228DC62C100A3FF05 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
-				8B92CD0328DC62D200A3FF05 /* Match.swift */,
+				90C4D77A28DDC86800E06274 /* Build.swift */,
 				8B92CD0A28DC63E000A3FF05 /* Keychain.swift */,
+				8B92CD0328DC62D200A3FF05 /* Match.swift */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -303,6 +306,7 @@
 				B30206811F5E3E9000DE6EBD /* DeliverfileProtocol.swift in Sources */,
 				B3BA65AA1F5A269100B34850 /* Runner.swift in Sources */,
 				B3BA65AF1F5A2D5C00B34850 /* RunnerArgument.swift in Sources */,
+				90C4D77B28DDC86800E06274 /* Build.swift in Sources */,
 				D5B8A5B31FFDC49E00536B24 /* ControlCommand.swift in Sources */,
 				1257253924B7992C00E04FA3 /* main.swift in Sources */,
 				B302067E1F5E3E9000DE6EBD /* PrecheckfileProtocol.swift in Sources */,


### PR DESCRIPTION
Resolves #333 

## What happened

- Provide 3 lanes for building:
  - AdHoc Staging
  - AdHoc Production
  - App Store

- Create `Build` to support preparing parameters before making the build.

## Insight

- Fastlane set `xcodebuildFormatter` with default option named `xcbeautify`, however, it doesn't work  after appending to  `xcodebuild` command. So I change it to `xcpretty`.
- For `exportOptions`, if we want to test on ios-template's generated app, we should comment current one, and uncomment `Constant.bundleId: "match \(type.method) \(Constant.bundleId)"` since our `bundle id` is not match with the design. Something like: Staging's bundle id should be `xxx.staging` but our ios-template's app is using without suffix `staging`.

## Proof Of Work

![Screen Shot 2022-09-24 at 00 06 24](https://user-images.githubusercontent.com/17830319/192023030-f10d2a67-6733-4430-9a95-32c535e0b770.png)
