### PR TITLE
[#355] Fix: Multi parameters func trigger wrongly for parameter with generics <T,U>

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -116,5 +116,5 @@ custom_rules:
   multiline_arguments_one_per_line:
     name: 'Multiline Arguments One Per Line'
     message: 'Arguments should be either on the same line, or one per line.'
-    regex: '[^\n\r]\(\n([^\(])*([^\n\r],([^\n\r])*[\w]+)([^\)])*\n(\s)*\)'
+    regex: '[^\n\r]\(\n([^\(<])*([^\n\r],([^\n\r])*[\w]+)([^\)])*\n(\s)*\)'
     severity: warning


### PR DESCRIPTION
https://github.com/nimblehq/ios-templates/issues/355

## What happened

Fix false linting when function includes multi items generics `<T, U>`.
  
## Insight

Ignore multi items generics in multiline argument. Only affect generics in multiline only.
 
## Proof Of Work

Before

<img width="826" alt="Screen Shot 2022-09-27 at 09 49 56" src="https://user-images.githubusercontent.com/6356137/192425618-3562273a-79c5-4822-a928-9bac66a3421f.png">


After

<img width="422" alt="Screen Shot 2022-09-27 at 09 51 50" src="https://user-images.githubusercontent.com/6356137/192425585-36d99cc2-d540-40f3-bcce-f64932b5a87f.png">
<img width="742" alt="Screen Shot 2022-09-27 at 09 50 13" src="https://user-images.githubusercontent.com/6356137/192425594-82fabec8-a799-4452-b62f-c4b1deb28896.png">
