### PR TITLE
[#340] As a developer, I can download dSYM file from AppStore with Fastlane Swift

### DIFF
--- a/fastlane/Constants/Constant.swift
+++ b/fastlane/Constants/Constant.swift
@@ -43,6 +43,7 @@ enum Constant {
     // MARK: - Symbol
 
     static let uploadSymbolsBinaryPath: String = "./Pods/FirebaseCrashlytics/upload-symbols"
+    static let dsymSuffix: String = ".dSYM.zip"
 }
 
 extension Constant {
@@ -81,7 +82,7 @@ extension Constant {
 
         var dsymPath: String {
             let outputDirectoryURL = URL(fileURLWithPath: Constant.outputPath)
-            return outputDirectoryURL.appendingPathComponent(productName + ".app.dSYM.zip").relativePath
+            return outputDirectoryURL.appendingPathComponent(productName + ".app" + Constant.dsymSuffix).relativePath
         }
     }
 

--- a/fastlane/Constants/Constant.swift
+++ b/fastlane/Constants/Constant.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2022 Nimble. All rights reserved.
 //
 
+import Foundation
+
 enum Constant {
 
     // MARK: - App Store
@@ -75,6 +77,11 @@ extension Constant {
             case .staging: return "\(googleServiceFolder)/Staging/\(infoName)"
             case .production: return "\(googleServiceFolder)/Production/\(infoName)"
             }
+        }
+
+        var dsymPath: String {
+            let outputDirectoryURL = URL(fileURLWithPath: Constant.outputPath)
+            return outputDirectoryURL.appendingPathComponent(productName + ".app.dSYM.zip").relativePath
         }
     }
 

--- a/fastlane/Constants/Constant.swift
+++ b/fastlane/Constants/Constant.swift
@@ -43,7 +43,7 @@ enum Constant {
     // MARK: - Symbol
 
     static let uploadSymbolsBinaryPath: String = "./Pods/FirebaseCrashlytics/upload-symbols"
-    static let dsymSuffix: String = ".dSYM.zip"
+    static let dSYMSuffix: String = ".dSYM.zip"
 }
 
 extension Constant {
@@ -82,7 +82,7 @@ extension Constant {
 
         var dsymPath: String {
             let outputDirectoryURL = URL(fileURLWithPath: Constant.outputPath)
-            return outputDirectoryURL.appendingPathComponent(productName + ".app" + Constant.dsymSuffix).relativePath
+            return outputDirectoryURL.appendingPathComponent(productName + ".app" + Constant.dSYMSuffix).relativePath
         }
     }
 

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -42,7 +42,7 @@ class Fastfile: LaneFile {
         desc("Build Staging app and upload to Firebase")
 
         buildAdHocStagingLane()
-        Symbol.uploadToCrashlytics(environment: .staging)
+        Symbol.uploadAdhocToCrashlytics(environment: .staging)
         // TODO: - Make release notes
         Distribution.uploadToFirebase(environment: .staging, releaseNotes: "")
     }
@@ -51,7 +51,7 @@ class Fastfile: LaneFile {
         desc("Build Staging app and upload to Firebase")
 
         buildAdHocProductionLane()
-        Symbol.uploadToCrashlytics(environment: .production)
+        Symbol.uploadAdhocToCrashlytics(environment: .production)
         // TODO: - Make release notes
         Distribution.uploadToFirebase(environment: .production, releaseNotes: "")
     }
@@ -61,5 +61,10 @@ class Fastfile: LaneFile {
 
         buildAppStoreLane()
         Distribution.uploadToAppStore()
+        // TODO: - Use our Version helpers instead
+        let versionNumber = getVersionNumber()
+        let buildNumber = getBuildNumber()
+        Symbol.downloadFromAppStore(versionNumber: versionNumber, buildNumber: buildNumber)
+        Symbol.uploadAppStoreToCrashlytics(versionNumber: versionNumber, buildNumber: buildNumber)
     }
 }

--- a/fastlane/Helpers/Symbol.swift
+++ b/fastlane/Helpers/Symbol.swift
@@ -30,7 +30,7 @@ enum Symbol {
     ) {
         // This file name from download_dsyms action
         // https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/download_dsyms.rb#L183
-        let dsymFileName = "\(environment.bundleId)-\(versionNumber)-\(buildNumber).dSYM.zip"
+        let dsymFileName = "\(environment.bundleId)-\(versionNumber)-\(buildNumber)\(Constant.dsymSuffix)"
         let outputDirectoryURL = URL(fileURLWithPath: Constant.outputPath)
         let dsymPath = outputDirectoryURL.appendingPathComponent(dsymFileName).relativePath
         guard FileManager.default.fileExists(atPath: dsymPath) else {
@@ -52,7 +52,11 @@ enum Symbol {
     ) {
         // Create output directory if needed
         let outputDirectoryURL = URL(fileURLWithPath: Constant.outputPath)
-        try? FileManager.default.createDirectory(atPath: outputDirectoryURL.relativePath, withIntermediateDirectories: true)
+        do {
+            try FileManager.default.createDirectory(atPath: outputDirectoryURL.relativePath, withIntermediateDirectories: true)
+        } catch {
+            log(message: "Having issues \(error.localizedDescription) when creating directory \(Constant.outputPath)")
+        }
 
         downloadDsyms(
             username: Constant.userName,

--- a/fastlane/Helpers/Symbol.swift
+++ b/fastlane/Helpers/Symbol.swift
@@ -30,7 +30,7 @@ enum Symbol {
     ) {
         // This file name from download_dsyms action
         // https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/download_dsyms.rb#L183
-        let dsymFileName = "\(environment.bundleId)-\(versionNumber)-\(buildNumber)\(Constant.dsymSuffix)"
+        let dsymFileName = "\(environment.bundleId)-\(versionNumber)-\(buildNumber)\(Constant.dSYMSuffix)"
         let outputDirectoryURL = URL(fileURLWithPath: Constant.outputPath)
         let dsymPath = outputDirectoryURL.appendingPathComponent(dsymFileName).relativePath
         guard FileManager.default.fileExists(atPath: dsymPath) else {

--- a/fastlane/Helpers/Symbol.swift
+++ b/fastlane/Helpers/Symbol.swift
@@ -10,18 +10,58 @@ import Foundation
 
 enum Symbol {
 
-    static func uploadToCrashlytics(environment: Constant.Environment) {
-        let buildURL = URL(fileURLWithPath: Constant.outputPath)
-        let dsymURL = buildURL.appendingPathComponent(environment.productName + ".app.dSYM.zip")
-        guard FileManager.default.fileExists(atPath: dsymURL.relativePath) else {
+    static func uploadAdhocToCrashlytics(environment: Constant.Environment) {
+        guard FileManager.default.fileExists(atPath: environment.dsymPath) else {
             return log(message: "Can't find the dSYM file")
         }
         uploadSymbolsToCrashlytics(
-            dsymPath: dsymURL.relativePath,
+            dsymPath: environment.dsymPath,
             gspPath: .userDefined(environment.gspPath),
             appId: .userDefined(environment.firebaseAppId),
             binaryPath: .userDefined(Constant.uploadSymbolsBinaryPath),
             debug: true // We sometimes has issues with dSYM files, so I enabled this flag.
+        )
+    }
+
+    static func uploadAppStoreToCrashlytics(
+        versionNumber: String,
+        buildNumber: String,
+        environment: Constant.Environment = .production
+    ) {
+        // This file name from download_dsyms action
+        // https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/download_dsyms.rb#L183
+        let dsymFileName = "\(environment.bundleId)-\(versionNumber)-\(buildNumber).dSYM.zip"
+        let outputDirectoryURL = URL(fileURLWithPath: Constant.outputPath)
+        let dsymPath = outputDirectoryURL.appendingPathComponent(dsymFileName).relativePath
+        guard FileManager.default.fileExists(atPath: dsymPath) else {
+            return log(message: "Can't find the dSYM file")
+        }
+        uploadSymbolsToCrashlytics(
+            dsymPath: dsymPath,
+            gspPath: .userDefined(environment.gspPath),
+            appId: .userDefined(environment.firebaseAppId),
+            binaryPath: .userDefined(Constant.uploadSymbolsBinaryPath),
+            debug: true // We sometimes has issues with dSYM files, so I enabled this flag.
+        )
+    }
+
+    static func downloadFromAppStore(
+        versionNumber: String,
+        buildNumber: String,
+        environment: Constant.Environment = .production
+    ) {
+        // Create output directory if needed
+        let outputDirectoryURL = URL(fileURLWithPath: Constant.outputPath)
+        try? FileManager.default.createDirectory(atPath: outputDirectoryURL.relativePath, withIntermediateDirectories: true)
+
+        downloadDsyms(
+            username: Constant.userName,
+            appIdentifier: environment.bundleId,
+            teamId: .userDefined(Constant.teamId),
+            version: .userDefined(versionNumber),
+            buildNumber: .userDefined(buildNumber),
+            outputDirectory: .userDefined(Constant.outputPath),
+            waitForDsymProcessing: .userDefined(true)
         )
     }
 }


### PR DESCRIPTION
Resolve #340

## What happened

Add functions to support downloading dSYM files from AppStore
 
## Insight

- I added a function to support downloading dSYM file from AppStore and uploading it to Firebase.
- Because of the file name, there will be 2 functions for uploading, one for ad hoc and one for the app store method.
 
## Proof Of Work

<img width="1076" alt="Screen Shot 2022-09-28 at 13 46 31" src="https://user-images.githubusercontent.com/19943832/192712535-9ae6a88d-0202-4b7e-82ca-42896b739209.png">
