### PR TITLE
[#342] As a developer, I can get and set build number and version number of the project with Fastlane Swift

### DIFF
--- a/fastlane/Constants/Constant.swift
+++ b/fastlane/Constants/Constant.swift
@@ -34,6 +34,7 @@ enum Constant {
     static let outputPath = "./Output"
     static let buildPath = "\(outputPath)/Build"
     static let derivedDataPath = "\(outputPath)/DerivedData"
+    static let projectPath: String = "./{PROJECT_NAME}.xcodeproj"
 
     // MARK: - Project
 
@@ -45,6 +46,10 @@ enum Constant {
 
     static let uploadSymbolsBinaryPath: String = "./Pods/FirebaseCrashlytics/upload-symbols"
     static let dSYMSuffix: String = ".dSYM.zip"
+    
+    // MARK: - Build and Version
+
+    static let manualVersion: String = ""
 }
 
 extension Constant {

--- a/fastlane/Constants/Constant.swift
+++ b/fastlane/Constants/Constant.swift
@@ -34,7 +34,7 @@ enum Constant {
     static let outputPath = "./Output"
     static let buildPath = "\(outputPath)/Build"
     static let derivedDataPath = "\(outputPath)/DerivedData"
-    static let projectPath: String = "./{PROJECT_NAME}.xcodeproj"
+    static let projectPath: String = "./\(projectName).xcodeproj"
 
     // MARK: - Project
 

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -89,7 +89,7 @@ class Fastfile: LaneFile {
     // MARK: - Private Helper
 
     private func setAppVersion() {
-        desc("check if any specific version number in build environment")
+        desc("Check if any specific version number in build environment")
         guard !Constant.manualVersion.isEmpty else { return }
         incrementVersionNumber(
             versionNumber: .userDefined(Constant.manualVersion)
@@ -97,7 +97,7 @@ class Fastfile: LaneFile {
     }
 
     private func bumpBuild(buildNumber: Int = numberOfCommits()) {
-        desc("set build number with number of commits")
+        desc("Set build number with number of commits")
         incrementBuildNumber(
             buildNumber: .userDefined(String(buildNumber)),
             xcodeproj: .userDefined(Constant.projectPath))

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -81,17 +81,16 @@ class Fastfile: LaneFile {
 
     private func setAppVersion() {
         desc("check if any specific version number in build environment")
-        if !Constant.manualVersion.isEmpty {
-            incrementVersionNumber(
-                versionNumber: .userDefined(Constant.manualVersion)
-            )
-        }
+        guard !Constant.manualVersion.isEmpty else { return }
+        incrementVersionNumber(
+            versionNumber: .userDefined(Constant.manualVersion)
+        )
     }
 
-    private func bumpBuild() {
+    private func bumpBuild(buildNumber: Int = numberOfCommits()) {
         desc("set build number with number of commits")
         incrementBuildNumber(
-            buildNumber: .userDefined(String(numberOfCommits())),
+            buildNumber: .userDefined(String(buildNumber)),
             xcodeproj: .userDefined(Constant.projectPath))
     }
 }

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -41,6 +41,9 @@ class Fastfile: LaneFile {
     func buildStagingAndUploadToFirebaseLane() {
         desc("Build Staging app and upload to Firebase")
 
+        setAppVersion()
+        bumpBuild()
+
         buildAdHocStagingLane()
         Symbol.uploadAdhocToCrashlytics(environment: .staging)
         // TODO: - Make release notes
@@ -50,6 +53,9 @@ class Fastfile: LaneFile {
     func buildProductionAndUploadToFirebaseLane() {
         desc("Build Staging app and upload to Firebase")
 
+        setAppVersion()
+        bumpBuild()
+
         buildAdHocProductionLane()
         Symbol.uploadAdhocToCrashlytics(environment: .production)
         // TODO: - Make release notes
@@ -58,6 +64,9 @@ class Fastfile: LaneFile {
 
     func buildAndUploadToAppStoreLane() {
         desc("Build Production app and upload to App Store")
+
+        setAppVersion()
+        bumpBuild()
 
         buildAppStoreLane()
         AppStoreAuthentication.connectAPIKey()

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -76,4 +76,22 @@ class Fastfile: LaneFile {
         AppStoreAuthentication.connectAPIKey()
         Distribution.uploadToTestFlight()
     }
+
+    // MARK: - Private Helper
+
+    private func setAppVersion() {
+        desc("check if any specific version number in build environment")
+        if !Constant.manualVersion.isEmpty {
+            incrementVersionNumber(
+                versionNumber: .userDefined(Constant.manualVersion)
+            )
+        }
+    }
+
+    private func bumpBuild() {
+        desc("set build number with number of commits")
+        incrementBuildNumber(
+            buildNumber: .userDefined(String(numberOfCommits())),
+            xcodeproj: .userDefined(Constant.projectPath))
+    }
 }

--- a/fastlane/Helpers/Version.swift
+++ b/fastlane/Helpers/Version.swift
@@ -1,0 +1,48 @@
+//
+//  Version.swift
+//  FastlaneRunner
+//
+//  Created by Khanh on 26/09/2022.
+//  Copyright © 2022 Nimble. All rights reserved.
+//
+
+enum Version {
+    
+    // MARK: - Getting
+
+    static func getVersionNumber() -> String {
+        FastlaneRunner.getVersionNumber(
+            xcodeproj: .userDefined(Constant.projectPath),
+            target: .userDefined(Constant.projectName)
+        )
+    }
+
+    static func getBuildNumber() -> String {
+        FastlaneRunner.getBuildNumber(
+            xcodeproj: .userDefined(Constant.projectPath)
+        )
+    }
+
+    static func getVersionAndBuildNumber() -> String {
+        "\(getVersionNumber()) (Build: \(getBuildNumber())"
+    }
+
+    static var releaseTag: String {
+        "release/\(getVersionNumber())/\(numberOfCommits())"
+    }
+
+    // MARK: - Setting
+    static func setVersionNumber() {
+        incrementVersionNumber(
+            versionNumber: .userDefined(getVersionNumber()),
+            xcodeproj: .userDefined(Constant.projectPath)
+        )
+    }
+
+    static func setBuildNumber() {
+        incrementBuildNumber(
+            buildNumber: .userDefined(getBuildNumber()),
+            xcodeproj: .userDefined(Constant.projectPath)
+        )
+    }
+}

--- a/fastlane/Helpers/Version.swift
+++ b/fastlane/Helpers/Version.swift
@@ -9,18 +9,34 @@
 enum Version {
     
     // MARK: - Getting
-
-    static func getVersionNumber() -> String {
-        FastlaneRunner.getVersionNumber(
-            xcodeproj: .userDefined(Constant.projectPath),
-            target: .userDefined(Constant.projectName)
-        )
+    
+    static var versionNumber: String {
+        get {
+            FastlaneRunner.getVersionNumber(
+                xcodeproj: .userDefined(Constant.projectPath),
+                target: .userDefined(Constant.projectName)
+            )
+        }
+        
+        set {
+            incrementVersionNumber(
+                versionNumber: .userDefined(newValue),
+                xcodeproj: .userDefined(Constant.projectPath)
+            )
+        }
     }
+    
+    static var buildNumber: String {
+        get {
+            FastlaneRunner.getBuildNumber(xcodeproj: .userDefined(Constant.projectPath))
+        }
 
-    static func getBuildNumber() -> String {
-        FastlaneRunner.getBuildNumber(
-            xcodeproj: .userDefined(Constant.projectPath)
-        )
+        set {
+            incrementBuildNumber(
+                buildNumber: .userDefined(newValue),
+                xcodeproj: .userDefined(Constant.projectPath)
+            )
+        }
     }
 
     static func getVersionAndBuildNumber() -> String {
@@ -28,21 +44,6 @@ enum Version {
     }
 
     static var releaseTag: String {
-        "release/\(getVersionNumber())/\(numberOfCommits())"
-    }
-
-    // MARK: - Setting
-    static func setVersionNumber() {
-        incrementVersionNumber(
-            versionNumber: .userDefined(getVersionNumber()),
-            xcodeproj: .userDefined(Constant.projectPath)
-        )
-    }
-
-    static func setBuildNumber() {
-        incrementBuildNumber(
-            buildNumber: .userDefined(getBuildNumber()),
-            xcodeproj: .userDefined(Constant.projectPath)
-        )
+        "release/\(versionNumber)"
     }
 }

--- a/fastlane/Helpers/Version.swift
+++ b/fastlane/Helpers/Version.swift
@@ -40,7 +40,7 @@ enum Version {
     }
 
     static func getVersionAndBuildNumber() -> String {
-        "\(getVersionNumber()) (Build: \(getBuildNumber())"
+        "\(versionNumber) (Build: \(buildNumber)"
     }
 
     static var releaseTag: String {

--- a/fastlane/swift/FastlaneSwiftRunner/FastlaneSwiftRunner.xcodeproj/project.pbxproj
+++ b/fastlane/swift/FastlaneSwiftRunner/FastlaneSwiftRunner.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		1257253924B7992C00E04FA3 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1257253824B7992B00E04FA3 /* main.swift */; };
 		1267C3F42773A43E004DE48A /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1267C3F32773A43E004DE48A /* Atomic.swift */; };
 		12D2EB8D2620D83C00844013 /* OptionalConfigValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12D2EB8C2620D83B00844013 /* OptionalConfigValue.swift */; };
+		1C2D0FA528E4512E0059FF5A /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C2D0FA428E4512E0059FF5A /* Version.swift */; };
 		8B92CD0428DC62D200A3FF05 /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B92CD0328DC62D200A3FF05 /* Match.swift */; };
 		8B92CD0728DC638800A3FF05 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B92CD0628DC638800A3FF05 /* Constant.swift */; };
 		8B92CD0928DC63A700A3FF05 /* Secret.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B92CD0828DC63A700A3FF05 /* Secret.swift */; };
@@ -69,6 +70,7 @@
 		1257253824B7992B00E04FA3 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = main.swift; path = ../main.swift; sourceTree = "<group>"; };
 		1267C3F32773A43E004DE48A /* Atomic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Atomic.swift; path = ../Atomic.swift; sourceTree = "<group>"; };
 		12D2EB8C2620D83B00844013 /* OptionalConfigValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = OptionalConfigValue.swift; path = ../OptionalConfigValue.swift; sourceTree = "<group>"; };
+		1C2D0FA428E4512E0059FF5A /* Version.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Version.swift; path = ../../Helpers/Version.swift; sourceTree = "<group>"; };
 		8B92CD0328DC62D200A3FF05 /* Match.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Match.swift; path = ../../Helpers/Match.swift; sourceTree = "<group>"; };
 		8B92CD0628DC638800A3FF05 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Constant.swift; path = ../../Constants/Constant.swift; sourceTree = "<group>"; };
 		8B92CD0828DC63A700A3FF05 /* Secret.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Secret.swift; path = ../../Constants/Secret.swift; sourceTree = "<group>"; };
@@ -126,6 +128,7 @@
 			isa = PBXGroup;
 			children = (
 				90F4F4CA28E4455C008BDAE5 /* AppStoreAuthentication.swift */,
+				1C2D0FA428E4512E0059FF5A /* Version.swift */,
 				90C4D77A28DDC86800E06274 /* Build.swift */,
 				90C4D77C28E0AB2A00E06274 /* Distribution.swift */,
 				8B92CD0A28DC63E000A3FF05 /* Keychain.swift */,
@@ -295,6 +298,7 @@
 				D5D1DE991FFEE8EA00502A00 /* RubyCommandable.swift in Sources */,
 				D55B28C41F6C588300DC42C5 /* Gymfile.swift in Sources */,
 				8B9386D728E2A8630045D709 /* Symbol.swift in Sources */,
+				1C2D0FA528E4512E0059FF5A /* Version.swift in Sources */,
 				8B92CD0B28DC63E000A3FF05 /* Keychain.swift in Sources */,
 				B302067D1F5E3E9000DE6EBD /* MatchfileProtocol.swift in Sources */,
 				1267C3F42773A43E004DE48A /* Atomic.swift in Sources */,

--- a/fastlane/swift/FastlaneSwiftRunner/FastlaneSwiftRunner.xcodeproj/project.pbxproj
+++ b/fastlane/swift/FastlaneSwiftRunner/FastlaneSwiftRunner.xcodeproj/project.pbxproj
@@ -128,12 +128,12 @@
 			isa = PBXGroup;
 			children = (
 				90F4F4CA28E4455C008BDAE5 /* AppStoreAuthentication.swift */,
-				1C2D0FA428E4512E0059FF5A /* Version.swift */,
 				90C4D77A28DDC86800E06274 /* Build.swift */,
 				90C4D77C28E0AB2A00E06274 /* Distribution.swift */,
 				8B92CD0A28DC63E000A3FF05 /* Keychain.swift */,
 				8B92CD0328DC62D200A3FF05 /* Match.swift */,
 				8B9386D628E2A8630045D709 /* Symbol.swift */,
+				1C2D0FA428E4512E0059FF5A /* Version.swift */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";


### PR DESCRIPTION
Resolves #342 

## What happened

- Created `get` and `set` functions for build and version numbers.
 
## Insight

- Created `enum Version` that contains set and get functions.
- Created private helper function `setAppVersion` and `bumpToVersion`.
- Added  `manualVersion` variable to `Constant`, developer can set manual version app directly or leave it empty.
- Added project path variable to `Constant`.
## Proof Of Work

**Setting, getting functions:**

<img width="400" alt="versionfunctions" src="https://user-images.githubusercontent.com/25881847/192753729-00bf5ca3-bd9c-492d-9ebe-3b9d225cd485.png">

**private helper function:**
<img width="400" alt="privatefunc" src="https://user-images.githubusercontent.com/25881847/192753565-e3132e94-40c5-44bc-9491-1f7ff26f430f.png">



