### PR TITLE
[#337] As a developer, I can upload the build to TestFlight with Fastlane Swift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,12 +64,13 @@ fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
 fastlane/xcov_output
+fastlane/FastlaneRunner
 
 # Sourcery
 *.generated.swift
 
-# Derived Data folder
-DerivedData
+# Output folder (Derived Data, Build, ipa, etc)
+Output
 
 # Tuist
 .tuist-generated

--- a/fastlane/Constants/Constant.swift
+++ b/fastlane/Constants/Constant.swift
@@ -14,6 +14,7 @@ enum Constant {
 
     static let appStoreKeyId = "<#appStoreKeyId#>"
     static let appStoreIssuerId = "<#appStoreIssuerId#>"
+    static let testFlightTesterGroups = ["<#group1#>", "<#group2#>"]
 
     // MARK: - Firebase
 

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -69,7 +69,7 @@ class Fastfile: LaneFile {
         Symbol.uploadAppStoreToCrashlytics(versionNumber: versionNumber, buildNumber: buildNumber)
     }
 
-    func buidAnhUploadToTestFlightLane() {
+    func buildAndUploadToTestFlightLane() {
         desc("Build Production app and upload to TestFlight")
 
         buildAppStoreLane()

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -68,4 +68,12 @@ class Fastfile: LaneFile {
         Symbol.downloadFromAppStore(versionNumber: versionNumber, buildNumber: buildNumber)
         Symbol.uploadAppStoreToCrashlytics(versionNumber: versionNumber, buildNumber: buildNumber)
     }
+
+    func buidAnhUploadToTestFlightLane() {
+        desc("Build Production app and upload to TestFlight")
+
+        buildAppStoreLane()
+        AppStoreAuthentication.connectAPIKey()
+        Distribution.uploadToTestFlight()
+    }
 }

--- a/fastlane/Helpers/Distribution.swift
+++ b/fastlane/Helpers/Distribution.swift
@@ -38,6 +38,24 @@ enum Distribution {
         )
     }
 
+    static func uploadToTestFlight(
+        environment: Constant.Environment = .production,
+        changeLog: String = "",
+        betaAppReviewInfo: [String: Any] = [:],
+        groups: [String] = Constant.testFlightTesterGroups
+    ) {
+        let ipaPath = makeIPAPath(environment: environment)
+        testflight(
+            appIdentifier: .userDefined(environment.bundleId),
+            ipa: .userDefined(ipaPath),
+            demoAccountRequired: .userDefined(betaAppReviewInfo.isEmpty),
+            betaAppReviewInfo: .userDefined(betaAppReviewInfo),
+            changelog: .userDefined(changeLog),
+            skipWaitingForBuildProcessing: .userDefined(true),
+            groups: .userDefined(groups)
+        )
+    }
+
     private static func makeIPAPath(environment: Constant.Environment) -> String {
         "\(Constant.outputPath)/\(environment.productName).ipa"
     }


### PR DESCRIPTION
#337

## What happened

- At `Distribution`, add TestFlight uploading function.
- At `Fastfile`, add upload build to TestFlight lane.
 
## Insight

- Since FastlaneRunner is an executable file and it's changed over time when building Fastlane swift project, so we don't need to commit to source code. I added it to `gitignore`.
- Also added the `Output` folder into `gitignore`.

## Proof Of Work

![Screen Shot 2022-09-29 at 09 57 24](https://user-images.githubusercontent.com/17830319/192930876-5cf7d862-2625-44e6-b8cc-a578e344dbd2.png)

![Screen Shot 2022-09-29 at 09 57 41](https://user-images.githubusercontent.com/17830319/192930879-eef19230-cd3f-4c69-8238-2bb56b701596.png)

![Screen Shot 2022-09-29 at 10 22 07](https://user-images.githubusercontent.com/17830319/192931342-770b4031-85c4-4b6e-96d2-5b6eb2451178.png)
