### PR TITLE
[#343] As a developer, I can register new device with Fastlane Swift

### DIFF
--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -112,4 +112,20 @@ class Fastfile: LaneFile {
             devices: Constant.devices
         )
     }
+
+    // MARK: - Register device
+
+    func registerNewDeviceLane() {
+        let deviceName = prompt(text: "Enter the device name")
+        let deviceUDID = prompt(text: "Enter the device UDID:")
+
+        registerDevice(
+            name: deviceName,
+            udid: deviceUDID,
+            teamId: .userDefined(Constant.teamId)
+        )
+
+        Match.syncCodeSigning(type: .development, appIdentifier: [], isForce: true)
+        Match.syncCodeSigning(type: .adHoc, appIdentifier: [], isForce: true)
+    }
 }

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -116,7 +116,7 @@ class Fastfile: LaneFile {
     // MARK: - Register device
 
     func registerNewDeviceLane() {
-        let deviceName = prompt(text: "Enter the device name")
+        let deviceName = prompt(text: "Enter the device name:")
         let deviceUDID = prompt(text: "Enter the device UDID:")
 
         registerDevice(


### PR DESCRIPTION
#343 

## What happened

- Create a lane to register new device using `registerDevice()`.
 
## Insight

- Implement `registerDevice` lane that matches [current ruby implementation](https://github.com/nimblehq/ios-templates/blob/5664de6fc4a9da259295c4c1a1d3841d69b1dd72/fastlane/Fastfile#L89).
- `registerDevice` lane requires `device name`, `UDID`, `teamID` to register a new device.
 
## Proof Of Work

<img width="500" src="https://user-images.githubusercontent.com/25881847/193180810-634610bb-9999-4503-aea2-cd1f53bb6938.png">

