### PR TITLE
[#347] As a developer, I can have a lane in Fastfile.swift for clean up data

### DIFF
--- a/fastlane/Constants/Constant.swift
+++ b/fastlane/Constants/Constant.swift
@@ -36,6 +36,7 @@ enum Constant {
     static let derivedDataPath = "\(outputPath)/DerivedData"
     static let projectPath: String = "./\(projectName).xcodeproj"
     static let testOutputDirectoryPath = "./fastlane/test_output"
+    static let xcovOutputDirectoryPath: String = "./fastlane/xcov_output"
 
     // MARK: - Project
 

--- a/fastlane/Constants/Constant.swift
+++ b/fastlane/Constants/Constant.swift
@@ -36,7 +36,6 @@ enum Constant {
     static let derivedDataPath = "\(outputPath)/DerivedData"
     static let projectPath: String = "./\(projectName).xcodeproj"
     static let testOutputDirectoryPath = "./fastlane/test_output"
-    static let xcovOutputDirectoryPath: String = "./fastlane/xcov_output"
 
     // MARK: - Project
 

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -128,4 +128,16 @@ class Fastfile: LaneFile {
         Match.syncCodeSigning(type: .development, appIdentifier: [], isForce: true)
         Match.syncCodeSigning(type: .adHoc, appIdentifier: [], isForce: true)
     }
+
+    // MARK: - Utilities
+
+    func cleanUpDerivedData() {
+        desc("Clean up derived data")
+        clearDerivedData(derivedDataPath: Constant.derivedDataPath)
+    }
+
+    func cleanUpXcov() {
+        desc("Clean up xcov output")
+        clearDerivedData(derivedDataPath: Constant.xcovOutputDirectoryPath)
+    }
 }

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -131,13 +131,8 @@ class Fastfile: LaneFile {
 
     // MARK: - Utilities
 
-    func cleanUpDerivedData() {
-        desc("Clean up derived data")
-        clearDerivedData(derivedDataPath: Constant.derivedDataPath)
-    }
-
-    func cleanUpXcov() {
-        desc("Clean up xcov output")
-        clearDerivedData(derivedDataPath: Constant.xcovOutputDirectoryPath)
+    func cleanUpOutput() {
+        desc("Clean up Output")
+        clearDerivedData(derivedDataPath: Constant.outputPath)
     }
 }

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -131,7 +131,7 @@ class Fastfile: LaneFile {
 
     // MARK: - Utilities
 
-    func cleanUpOutput() {
+    func cleanUpOutputLane() {
         desc("Clean up Output")
         clearDerivedData(derivedDataPath: Constant.outputPath)
     }


### PR DESCRIPTION
#347 

## What happened

- Created utility functions to clean up xcov output and derived data.
 
## Insight

- `cleanUpDerivedData` function for clean up derived data at path `./DerivedData`.
- `cleanUpXcov` function for cleaning up output of xcov at path `./fastlane/xcov_output`.
 
## Proof Of Work
![Screen Shot 2022-09-30 at 10 44 07](https://user-images.githubusercontent.com/25881847/193186793-f31f155f-9221-4c04-a48b-398ebf8ec49b.png)

