### PR TITLE
[Chore] [#348] Update README file according to the git-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <p align="center">
-  <img alt="Nimble logo" src="https://assets.nimblehq.co/logo/light/logo-light-text-320.png" />
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://assets.nimblehq.co/logo/dark/logo-dark-text-320.png">
+      <img alt="Nimble logo" src="https://assets.nimblehq.co/logo/light/logo-light-text-320.png">
+    </picture>
 </p>
 
 <p align="center">
@@ -39,7 +42,10 @@ and may be redistributed under the terms specified in the [LICENSE] file.
 
 ## About
 
-![Nimble](https://assets.nimblehq.co/logo/dark/logo-dark-text-160.png)
+<picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://assets.nimblehq.co/logo/dark/logo-dark-text-160.png">
+      <img alt="Nimble logo" src="https://assets.nimblehq.co/logo/light/logo-light-text-160.png">
+</picture>
 
 This project is maintained and funded by Nimble.
 


### PR DESCRIPTION
#348 

## What happened

- Update the logo to support the light/dark mode follow git-template
 
![Screen Shot 2565-09-16 at 5 52 49 PM](https://user-images.githubusercontent.com/12026942/190623363-c93a6d3a-9a41-4cd5-bd58-7ab7a40f8bfa.png)
 
## Insight

- Update the logo in README file follow Nimble's git-template
 
## Proof Of Work

**Light Theme Default**
<img width="600" alt="Screen Shot 2022-10-19 at 09 09 11" src="https://user-images.githubusercontent.com/24598204/196581822-35d94e1e-b519-45c4-adca-63f8c363eef1.png">

**Dark Theme Default**
<img width="600" alt="Screen Shot 2022-10-19 at 09 08 53" src="https://user-images.githubusercontent.com/24598204/196581833-bf2cc64c-93ec-4c2a-bb0a-89aa19c5caeb.png">
