### PR TITLE
[#351] Add steps in CI/CD templates to support upload builds and dSYM files to build artifacts of CI/CD platforms (Github Actions, Bitrise)

### DIFF
--- a/.github/workflows/deploy_AppStore.yml
+++ b/.github/workflows/deploy_AppStore.yml
@@ -75,11 +75,11 @@ jobs:
         APPSTORE_CONNECT_API_KEY: ${{ secrets.APPSTORE_CONNECT_API_KEY }}
 
     - name: Upload Artifacts
-      uses: softprops/action-gh-release@v1
+      uses: actions/upload-artifact@v3
       with:
-        files: |
+        name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
+        path: |
           ${{ env.IPA_OUTPUT_PATH }}
           ${{ env.DSYM_OUTPUT_PATH }}
-        tag_name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
       env:
         TAG_TYPE: App_Store

--- a/.github/workflows/deploy_AppStore.yml
+++ b/.github/workflows/deploy_AppStore.yml
@@ -73,3 +73,13 @@ jobs:
       run: bundle exec fastlane build_and_upload_appstore_app
       env:
         APPSTORE_CONNECT_API_KEY: ${{ secrets.APPSTORE_CONNECT_API_KEY }}
+
+    - name: Upload Artifacts
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          ${{ env.IPA_OUTPUT_PATH }}
+          ${{ env.DSYM_OUTPUT_PATH }}
+        tag_name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
+      env:
+        TAG_TYPE: App_Store

--- a/.github/workflows/deploy_Firebase.yml
+++ b/.github/workflows/deploy_Firebase.yml
@@ -80,11 +80,11 @@ jobs:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
 
     - name: Upload Artifacts
-      uses: softprops/action-gh-release@v1
+      uses: actions/upload-artifact@v3
       with:
-        files: |
+        name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
+        path: |
           ${{ env.IPA_OUTPUT_PATH }}
           ${{ env.DSYM_OUTPUT_PATH }}
-        tag_name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
       env:
         TAG_TYPE: Staging_Firebase

--- a/.github/workflows/deploy_Firebase.yml
+++ b/.github/workflows/deploy_Firebase.yml
@@ -78,3 +78,13 @@ jobs:
       run: bundle exec fastlane build_and_upload_staging_app
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+
+    - name: Upload Artifacts
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          ${{ env.IPA_OUTPUT_PATH }}
+          ${{ env.DSYM_OUTPUT_PATH }}
+        tag_name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
+      env:
+        TAG_TYPE: Staging_Firebase

--- a/.github/workflows/deploy_Release_Firebase.yml
+++ b/.github/workflows/deploy_Release_Firebase.yml
@@ -74,11 +74,11 @@ jobs:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
 
     - name: Upload Artifacts
-      uses: softprops/action-gh-release@v1
+      uses: actions/upload-artifact@v3
       with:
-        files: |
+        name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
+        path: |
           ${{ env.IPA_OUTPUT_PATH }}
           ${{ env.DSYM_OUTPUT_PATH }}
-        tag_name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
       env:
         TAG_TYPE: Production_Firebase

--- a/.github/workflows/deploy_Release_Firebase.yml
+++ b/.github/workflows/deploy_Release_Firebase.yml
@@ -72,3 +72,13 @@ jobs:
       run: bundle exec fastlane build_and_upload_production_app
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+
+    - name: Upload Artifacts
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          ${{ env.IPA_OUTPUT_PATH }}
+          ${{ env.DSYM_OUTPUT_PATH }}
+        tag_name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
+      env:
+        TAG_TYPE: Production_Firebase

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -42,6 +42,10 @@ workflows:
         title: Build and upload Production app to App Store
         inputs:
         - lane: build_and_upload_appstore_app
+    - deploy-to-bitrise-io:
+        inputs:
+        - deploy_path: $BUILD_PATH
+        is_always_run: false
     - cache-push@2:
         inputs:
         - cache_paths: |-
@@ -83,6 +87,10 @@ workflows:
         title: Build and Upload Production App
         inputs:
         - lane: build_and_upload_production_app
+    - deploy-to-bitrise-io:
+        inputs:
+        - deploy_path: $BUILD_PATH
+        is_always_run: false
     - cache-push@2:
         inputs:
         - cache_paths: |-
@@ -124,6 +132,10 @@ workflows:
         title: Build and Upload Staging App
         inputs:
         - lane: build_and_upload_staging_app
+    - deploy-to-bitrise-io:
+        inputs:
+        - deploy_path: $BUILD_PATH
+        is_always_run: false
     - cache-push@2:
         inputs:
         - cache_paths: |-

--- a/fastlane/Constants/Environments.rb
+++ b/fastlane/Constants/Environments.rb
@@ -27,4 +27,12 @@ class Environments
   def self.BUMP_APP_STORE_BUILD_NUMBER
     ENV['BUMP_APP_STORE_BUILD_NUMBER']
   end
+
+  def self.GITHUB_ACTIONS
+    ENV['GITHUB_ACTIONS']
+  end
+
+  def self.BITRISE_IO
+    ENV['BITRISE_IO']
+  end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,6 +9,7 @@ require './Managers/SymbolManager'
 require './Managers/DistributionManager'
 require './Managers/MatchManager'
 require './Managers/TestManager'
+require './Managers/EnvironmentManager'
 
 test_manager = TestManager.new(
   fastlane: self,
@@ -36,6 +37,13 @@ match_manager = MatchManager.new(
   keychain_password: Constants.KEYCHAIN_PASSWORD,
   is_ci: Environments.CI,
   username: DeliverableConstants.DEV_PORTAL_APPLE_ID
+)
+
+environment_manager = EnvironmentManager.new(
+  fastlane: self,
+  is_github_actions: Environments.GITHUB_ACTIONS,
+  is_bitrise: Environments.BITRISE_IO,
+  build_path: Constants.BUILD_PATH
 )
 
 before_all do
@@ -119,6 +127,7 @@ platform :ios do
       product_name: Constants.PRODUCT_NAME_STAGING,
       gsp_name: DeliverableConstants.GSP_STAGING
     )
+    environment_manager.save_build_context_to_ci(version_number: versioning_manager.version_number)
   end
 
   desc 'Build and upload Production app to Firebase'
@@ -139,6 +148,7 @@ platform :ios do
       product_name: Constants.PRODUCT_NAME_PRODUCTION,
       gsp_name: DeliverableConstants.GSP_PRODUCTION
     )
+    environment_manager.save_build_context_to_ci(version_number: versioning_manager.version_number)
   end
 
   desc 'upload develop build to Firebase app distribution'
@@ -193,6 +203,7 @@ platform :ios do
         gsp_name: DeliverableConstants.GSP_PRODUCTION
       )
     end
+    environment_manager.save_build_context_to_ci(version_number: versioning_manager.version_number)
   end
 
   desc 'upload develop build to App Store'

--- a/fastlane/Managers/EnvironmentManager.rb
+++ b/fastlane/Managers/EnvironmentManager.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class EnvironmentManager
+  def initialize(fastlane:, is_github_actions:, is_bitrise:, build_path:)
+    @fastlane = fastlane
+    @is_github_actions = is_github_actions
+    @is_bitrise = is_bitrise
+    @build_path = build_path
+  end
+
+  def save_build_context_to_ci(version_number:)
+    ipa_path =  Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::IPA_OUTPUT_PATH]
+    dsym_path = Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::DSYM_OUTPUT_PATH]
+    build_number = Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]
+
+    if @is_github_actions
+      @fastlane.sh("echo IPA_OUTPUT_PATH=#{ipa_path} >> $GITHUB_ENV")
+      @fastlane.sh("echo DSYM_OUTPUT_PATH=#{dsym_path} >> $GITHUB_ENV")
+      @fastlane.sh("echo BUILD_NUMBER=#{build_number} >> $GITHUB_ENV")
+      @fastlane.sh("echo VERSION_NUMBER=#{version_number} >> $GITHUB_ENV")
+    end
+    if @is_bitrise
+      @fastlane.sh("envman add --key BUILD_PATH --value '#{@build_path}'")
+    end
+  end
+end


### PR DESCRIPTION
close #351

## What happened

Add a step to upload `dsym` and `ipa` file to CICD.
- GitHub Actions: Upload files as artifact.
- Bitrise: Upload files as artifact.
 
## Insight

- Create a new fastlane helper `EnvironmentManager`  for saving build contexts: version, build number, files locations, to CICD.
- Use `EnvironmentManager` in `build_and_upload_appstore_app`, `build_and_upload_production_app`, and `build_and_upload_staging_app` to save lanes' output.
- Add `upload-artifact` to GitHub Actions to upload artifacts.
- GH Actions, there's an `.archive` file inside folder `./Build` so IPA and DSYM need to be specified individually to save space.
- Add `deploy-to-bitrise-io` to Bitrise to upload artifacts.

## Proof Of Work

https://github.com/blyscuit/ios-template-upload-build/actions/runs/3393119685

<img width="1021" alt="Screen Shot 2022-11-04 at 17 53 15" src="https://user-images.githubusercontent.com/6356137/199957973-f08da0c1-98f8-4e69-8bf2-994199a7968e.png">

<img width="1012" alt="Screen Shot 2022-11-02 at 12 27 30" src="https://user-images.githubusercontent.com/6356137/199405518-2d8d0979-f303-48d0-bf85-0d33239c7d34.png">
