### PR TITLE
[Chore] Update Project for Xcode 14

### DIFF
--- a/.github/workflows/test_upload_build_to_test_flight.yml
+++ b/.github/workflows/test_upload_build_to_test_flight.yml
@@ -14,7 +14,7 @@ on:
 jobs:    
   build:
     name: Build
-    runs-on: macOS-latest
+    runs-on: macOS-12
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.5.0

--- a/Podfile
+++ b/Podfile
@@ -53,6 +53,12 @@ post_install do |installer|
     target.build_configurations.each do |config|
       config.build_settings.delete 'IPHONEOS_DEPLOYMENT_TARGET'
       config.build_settings['ENABLE_BITCODE'] = 'NO'
+      # Fix some pods creating bunndle, asking for signing
+      if target.respond_to?(:product_type) and target.product_type == "com.apple.product-type.bundle"
+        target.build_configurations.each do |config|
+            config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
+        end
+      end
     end
   end
 end

--- a/Podfile
+++ b/Podfile
@@ -53,7 +53,7 @@ post_install do |installer|
     target.build_configurations.each do |config|
       config.build_settings.delete 'IPHONEOS_DEPLOYMENT_TARGET'
       config.build_settings['ENABLE_BITCODE'] = 'NO'
-      # Fix some pods creating bunndle, asking for signing
+      # Fix some pods creating bundle, asking for signing
       if target.respond_to?(:product_type) and target.product_type == "com.apple.product-type.bundle"
         target.build_configurations.each do |config|
             config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -183,8 +183,7 @@ platform :ios do
     builder.build_app_store(
       Constants.SCHEME_NAME_PRODUCTION,
       Constants.PRODUCT_NAME_PRODUCTION,
-      Constants.BUNDLE_ID_PRODUCTION,
-      true
+      Constants.BUNDLE_ID_PRODUCTION
     )
     upload_build_to_appstore
     if (Environments.SKIP_FIREBASE_DSYM || '') == ''

--- a/fastlane/Managers/BuildManager.rb
+++ b/fastlane/Managers/BuildManager.rb
@@ -14,13 +14,12 @@ class BuildManager
           bundle_identifier => "match AdHoc #{bundle_identifier}"
         }
       },
-      include_bitcode: false,
       output_name: product_name,
       disable_xcpretty: true
     )
   end
 
-  def build_app_store(scheme, product_name, bundle_identifier, include_bitcode)
+  def build_app_store(scheme, product_name, bundle_identifier)
     @fastlane.gym(
       scheme: scheme,
       export_method: 'app-store',
@@ -29,7 +28,6 @@ class BuildManager
           bundle_identifier => "match AppStore #{bundle_identifier}"
         }
       },
-      include_bitcode: include_bitcode,
       output_name: product_name
     )
   end


### PR DESCRIPTION
## What happened

Update Project for Xcode 14.
 
## Insight

- Some library will result in additional `bundle` and have to disable signing via `podfile`. https://stackoverflow.com/a/74129238/3736373
- Remove `bitcode` from `BuildManager` because bitcode will fail TestFlight upload.
- `macOS-latest` is [macOS-11](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md) and does not have Xcode 14. We should change to `macOS-latest` when Actions update the default https://github.com/actions/runner-images/issues/6384.
 
## Proof Of Work

https://github.com/nimblehq/ios-templates/actions/runs/3416880487