### PR TITLE
[#345] As a developer, I can have lanes in Fastfile.swift for sync match the project

### DIFF
--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -13,7 +13,7 @@ class Fastfile: LaneFile {
     // MARK: - Code signing
 
     func syncDevelopmentCodeSigningLane() {
-        desc("Sync the development match signing for the staging build")
+        desc("Sync the Development match signing for the Staging build")
         Match.syncCodeSigning(
             type: .development,
             appIdentifier: [Constant.stagingBundleId]
@@ -21,7 +21,7 @@ class Fastfile: LaneFile {
     }
 
     func syncAdHocStagingCodeSigningLane() {
-        desc("Sync the ad hoc match signing for the staging build")
+        desc("Sync the Ad Hoc match signing for the Staging build")
         Match.syncCodeSigning(
             type: .adHoc,
             appIdentifier: [Constant.stagingBundleId]
@@ -29,7 +29,7 @@ class Fastfile: LaneFile {
     }
 
     func syncAdHocProductionCodeSigningLane() {
-        desc("Sync the ad hoc match signing for the production build")
+        desc("Sync the Ad Hoc match signing for the Production build")
         Match.syncCodeSigning(
             type: .adHoc,
             appIdentifier: [Constant.productionBundleId]
@@ -37,7 +37,7 @@ class Fastfile: LaneFile {
     }
 
     func syncAppStoreCodeSigningLane() {
-        desc("Sync the app store match signing for the production build")
+        desc("Sync the App Store match signing for the Production build")
         Match.syncCodeSigning(
             type: .appStore,
             appIdentifier: [Constant.productionBundleId]

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -12,11 +12,36 @@ class Fastfile: LaneFile {
 
     // MARK: - Code signing
 
-    func syncCodeSigningLane() {
-        desc("This lane is for development purpose, will be removed after the migration")
-        Match.syncCodeSigning(type: .development, appIdentifier: ["co.nimblehq.ios.templates"])
-        Match.syncCodeSigning(type: .adHoc, appIdentifier: ["co.nimblehq.ios.templates"])
-        Match.syncCodeSigning(type: .appStore, appIdentifier: ["co.nimblehq.ios.templates"])
+    func syncDevelopmentCodeSigningLane() {
+        desc("Sync the development match signing for the staging build")
+        Match.syncCodeSigning(
+            type: .development,
+            appIdentifier: [Constant.stagingBundleId]
+        )
+    }
+
+    func syncAdHocStagingCodeSigningLane() {
+        desc("Sync the ad hoc match signing for the staging build")
+        Match.syncCodeSigning(
+            type: .adHoc,
+            appIdentifier: [Constant.stagingBundleId]
+        )
+    }
+
+    func syncAdHocProductionCodeSigningLane() {
+        desc("Sync the ad hoc match signing for the production build")
+        Match.syncCodeSigning(
+            type: .adHoc,
+            appIdentifier: [Constant.productionBundleId]
+        )
+    }
+
+    func syncAppStoreCodeSigningLane() {
+        desc("Sync the app store match signing for the production build")
+        Match.syncCodeSigning(
+            type: .appStore,
+            appIdentifier: [Constant.productionBundleId]
+        )
     }
 
     // MARK: - Build


### PR DESCRIPTION
- Resolves #345

## What happened

I created lanes in the `Fastfile.swift` to support [code signing](https://github.com/nimblehq/ios-templates/blob/master/fastlane/Fastfile?rgh-link-date=2022-09-16T04%3A49%3A14Z#L59) for the project with different methods and ids
 
## Insight

- I used `syncCodeSigning` from `Match` to support code signing.

Just run this on the terminal
```sh
$ bundle exec fastlane syncDevelopmentCodeSigningLane --disable_runner_upgrades
```
 
## Proof Of Work

<img width="1403" alt="Screenshot 2022-11-08 at 14 32 25" src="https://user-images.githubusercontent.com/19943832/200501767-7d0feca0-4f4c-45fa-a0c6-76e8db9ebaa8.png">

