### PR TITLE
[#346] As a developer, I can have lanes in Fastfile.swift for building and uploading

### DIFF
--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -36,7 +36,7 @@ class Fastfile: LaneFile {
         Build.appStore()
     }
 
-    // MARK: - Upload to Firebase
+    // MARK: - Upload builds to Firebase and AppStore
 
     func buildStagingAndUploadToFirebaseLane() {
         desc("Build Staging app and upload to Firebase")
@@ -45,9 +45,11 @@ class Fastfile: LaneFile {
         bumpBuild()
 
         buildAdHocStagingLane()
-        Symbol.uploadAdhocToCrashlytics(environment: .staging)
+
         // TODO: - Make release notes
         Distribution.uploadToFirebase(environment: .staging, releaseNotes: "")
+
+        Symbol.uploadToCrashlytics(environment: .staging)
     }
 
     func buildProductionAndUploadToFirebaseLane() {
@@ -57,9 +59,11 @@ class Fastfile: LaneFile {
         bumpBuild()
 
         buildAdHocProductionLane()
-        Symbol.uploadAdhocToCrashlytics(environment: .production)
+
         // TODO: - Make release notes
         Distribution.uploadToFirebase(environment: .production, releaseNotes: "")
+
+        Symbol.uploadToCrashlytics(environment: .production)
     }
 
     func buildAndUploadToAppStoreLane() {
@@ -69,39 +73,28 @@ class Fastfile: LaneFile {
         bumpBuild()
 
         buildAppStoreLane()
+
         AppStoreAuthentication.connectAPIKey()
         Distribution.uploadToAppStore()
-        // TODO: - Use our Version helpers instead
-        let versionNumber = getVersionNumber()
-        let buildNumber = getBuildNumber()
-        Symbol.downloadFromAppStore(versionNumber: versionNumber, buildNumber: buildNumber)
-        Symbol.uploadAppStoreToCrashlytics(versionNumber: versionNumber, buildNumber: buildNumber)
+
+        Symbol.uploadToCrashlytics(environment: .production)
     }
 
     func buildAndUploadToTestFlightLane() {
         desc("Build Production app and upload to TestFlight")
 
+        setAppVersion()
+        bumpBuild()
+
         buildAppStoreLane()
+
         AppStoreAuthentication.connectAPIKey()
         Distribution.uploadToTestFlight()
+
+        Symbol.uploadToCrashlytics(environment: .production)
     }
 
-    // MARK: - Private Helper
 
-    private func setAppVersion() {
-        desc("Check if any specific version number in build environment")
-        guard !Constant.manualVersion.isEmpty else { return }
-        incrementVersionNumber(
-            versionNumber: .userDefined(Constant.manualVersion)
-        )
-    }
-
-    private func bumpBuild(buildNumber: Int = numberOfCommits()) {
-        desc("Set build number with number of commits")
-        incrementBuildNumber(
-            buildNumber: .userDefined(String(buildNumber)),
-            xcodeproj: .userDefined(Constant.projectPath))
-    }
     // MARK: - Test
 
     func buildAndTestLane() {
@@ -134,5 +127,22 @@ class Fastfile: LaneFile {
     func cleanUpOutputLane() {
         desc("Clean up Output")
         clearDerivedData(derivedDataPath: Constant.outputPath)
+    }
+
+    // MARK: - Private Helper
+
+    private func setAppVersion() {
+        desc("Check if any specific version number in build environment")
+        guard !Constant.manualVersion.isEmpty else { return }
+        incrementVersionNumber(
+            versionNumber: .userDefined(Constant.manualVersion)
+        )
+    }
+
+    private func bumpBuild(buildNumber: Int = numberOfCommits()) {
+        desc("Set build number with number of commits")
+        incrementBuildNumber(
+            buildNumber: .userDefined(String(buildNumber)),
+            xcodeproj: .userDefined(Constant.projectPath))
     }
 }

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -143,6 +143,7 @@ class Fastfile: LaneFile {
         desc("Set build number with number of commits")
         incrementBuildNumber(
             buildNumber: .userDefined(String(buildNumber)),
-            xcodeproj: .userDefined(Constant.projectPath))
+            xcodeproj: .userDefined(Constant.projectPath)
+        )
     }
 }

--- a/fastlane/Helpers/Build.swift
+++ b/fastlane/Helpers/Build.swift
@@ -26,13 +26,11 @@ enum Build {
             outputDirectory: Constant.outputPath,
             outputName: .userDefined(environment.productName),
             includeSymbols: .userDefined(true),
-            includeBitcode: .userDefined(false),
             exportMethod: .userDefined(type.value),
             exportOptions: .userDefined([
-                // NOTE: bundleId should be `env.bundleId` instead of `Constant.bundleId`
-                // To test ios-template, uncomment right below
-//                Constant.bundleId: "match \(type.method) \(Constant.bundleId)"
-                environment.bundleId: "match \(type.method) \(environment.bundleId)"
+                "provisioningProfiles": [
+                    environment.bundleId: "match \(type.method) \(environment.bundleId)"
+                ]
             ]),
             buildPath: .userDefined(Constant.buildPath),
             derivedDataPath: .userDefined(Constant.derivedDataPath),

--- a/fastlane/Helpers/Build.swift
+++ b/fastlane/Helpers/Build.swift
@@ -26,7 +26,7 @@ enum Build {
             outputDirectory: Constant.outputPath,
             outputName: .userDefined(environment.productName),
             includeSymbols: .userDefined(true),
-            includeBitcode: .userDefined(type == .appStore),
+            includeBitcode: .userDefined(false),
             exportMethod: .userDefined(type.value),
             exportOptions: .userDefined([
                 // NOTE: bundleId should be `env.bundleId` instead of `Constant.bundleId`

--- a/fastlane/Helpers/Symbol.swift
+++ b/fastlane/Helpers/Symbol.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum Symbol {
 
-    static func uploadAdhocToCrashlytics(environment: Constant.Environment) {
+    static func uploadToCrashlytics(environment: Constant.Environment) {
         guard FileManager.default.fileExists(atPath: environment.dsymPath) else {
             return log(message: "Can't find the dSYM file")
         }
@@ -20,52 +20,6 @@ enum Symbol {
             appId: .userDefined(environment.firebaseAppId),
             binaryPath: .userDefined(Constant.uploadSymbolsBinaryPath),
             debug: true // We sometimes has issues with dSYM files, so I enabled this flag.
-        )
-    }
-
-    static func uploadAppStoreToCrashlytics(
-        versionNumber: String,
-        buildNumber: String,
-        environment: Constant.Environment = .production
-    ) {
-        // This file name from download_dsyms action
-        // https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/download_dsyms.rb#L183
-        let dsymFileName = "\(environment.bundleId)-\(versionNumber)-\(buildNumber)\(Constant.dSYMSuffix)"
-        let outputDirectoryURL = URL(fileURLWithPath: Constant.outputPath)
-        let dsymPath = outputDirectoryURL.appendingPathComponent(dsymFileName).relativePath
-        guard FileManager.default.fileExists(atPath: dsymPath) else {
-            return log(message: "Can't find the dSYM file")
-        }
-        uploadSymbolsToCrashlytics(
-            dsymPath: dsymPath,
-            gspPath: .userDefined(environment.gspPath),
-            appId: .userDefined(environment.firebaseAppId),
-            binaryPath: .userDefined(Constant.uploadSymbolsBinaryPath),
-            debug: true // We sometimes has issues with dSYM files, so I enabled this flag.
-        )
-    }
-
-    static func downloadFromAppStore(
-        versionNumber: String,
-        buildNumber: String,
-        environment: Constant.Environment = .production
-    ) {
-        // Create output directory if needed
-        let outputDirectoryURL = URL(fileURLWithPath: Constant.outputPath)
-        do {
-            try FileManager.default.createDirectory(atPath: outputDirectoryURL.relativePath, withIntermediateDirectories: true)
-        } catch {
-            log(message: "Having issues \(error.localizedDescription) when creating directory \(Constant.outputPath)")
-        }
-
-        downloadDsyms(
-            username: Constant.userName,
-            appIdentifier: environment.bundleId,
-            teamId: .userDefined(Constant.teamId),
-            version: .userDefined(versionNumber),
-            buildNumber: .userDefined(buildNumber),
-            outputDirectory: .userDefined(Constant.outputPath),
-            waitForDsymProcessing: .userDefined(true)
         )
     }
 }


### PR DESCRIPTION
- Resolves #346

## What happened

- Implement full functionality of build and upload builds to Firebase and App Store.
 
## Insight

- Because of Xcode14, we are now removing the download dSYM files from App Store (disable bit code). So I updated it in this pull request to support build and upload lanes.
- I also move all private helper function to the bottom.

 
## Proof Of Work

<img width="1034" alt="Screenshot 2022-11-08 at 21 52 01" src="https://user-images.githubusercontent.com/19943832/200719143-3c80d756-fc21-42ce-8573-44385c116306.png">
