### PR TITLE
[#382] [Fastlane Swift] Support uploading build and dSYM files to build artifacts of CI/CD platforms

### DIFF
--- a/fastlane/Constants/Constant.swift
+++ b/fastlane/Constants/Constant.swift
@@ -41,9 +41,9 @@ enum Constant {
 
     static var platform: PlatformType {
         if EnvironmentParser.bool(key: "BITRISE_IO") {
-            return .bitriseIO
+            return .bitrise
         } else if EnvironmentParser.bool(key: "GITHUB_ACTIONS") {
-            return .gitHubAction
+            return .gitHubActions
         }
         return .unknown
     }
@@ -130,7 +130,7 @@ extension Constant {
 
     enum PlatformType {
 
-        case gitHubAction, bitriseIO, unknown
+        case gitHubActions, bitrise, unknown
     }
 }
 

--- a/fastlane/Constants/Constant.swift
+++ b/fastlane/Constants/Constant.swift
@@ -37,6 +37,17 @@ enum Constant {
     static let projectPath: String = "./\(projectName).xcodeproj"
     static let testOutputDirectoryPath = "./fastlane/test_output"
 
+    // MARK: Platform
+
+    static var platform: PlatformType {
+        if EnvironmentParser.bool(key: "BITRISE_IO") {
+            return .bitriseIO
+        } else if EnvironmentParser.bool(key: "GITHUB_ACTIONS") {
+            return .gitHubAction
+        }
+        return .unknown
+    }
+
     // MARK: - Project
 
     static let stagingBundleId = "{BUNDLE_ID_STAGING}"
@@ -115,6 +126,11 @@ extension Constant {
             case .appStore: return "AppStore"
             }
         }
+    }
+
+    enum PlatformType {
+
+        case gitHubAction, bitriseIO, unknown
     }
 }
 

--- a/fastlane/Constants/Secret.swift
+++ b/fastlane/Constants/Secret.swift
@@ -9,9 +9,9 @@
 // This file will be added manually from CI platform (Github Actions / Bitrise / ...)
 enum Secret {
 
-    static let keychainPassword = "<#keychainPassword#>"
+    static let keychainPassword = EnvironmentParser.string(key: "KEYCHAIN_PASSWORD")
 
-    static let firebaseCLIToken = "<#firebaseCLIToken#>"
+    static let firebaseCLIToken = EnvironmentParser.string(key: "FIREBASE_CLI_TOKEN")
 
-    static let appstoreConnectAPIKey = "<#appstoreConnectAPIKey#>"
+    static let appstoreConnectAPIKey = EnvironmentParser.string(key: "APPSTORE_CONNECT_API_KEY")
 }

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -75,6 +75,8 @@ class Fastfile: LaneFile {
         Distribution.uploadToFirebase(environment: .staging, releaseNotes: "")
 
         Symbol.uploadToCrashlytics(environment: .staging)
+
+        Build.saveBuildContextToCI()
     }
 
     func buildProductionAndUploadToFirebaseLane() {
@@ -89,6 +91,8 @@ class Fastfile: LaneFile {
         Distribution.uploadToFirebase(environment: .production, releaseNotes: "")
 
         Symbol.uploadToCrashlytics(environment: .production)
+
+        Build.saveBuildContextToCI()
     }
 
     func buildAndUploadToAppStoreLane() {
@@ -103,6 +107,8 @@ class Fastfile: LaneFile {
         Distribution.uploadToAppStore()
 
         Symbol.uploadToCrashlytics(environment: .production)
+
+        Build.saveBuildContextToCI()
     }
 
     func buildAndUploadToTestFlightLane() {
@@ -117,6 +123,8 @@ class Fastfile: LaneFile {
         Distribution.uploadToTestFlight()
 
         Symbol.uploadToCrashlytics(environment: .production)
+
+        Build.saveBuildContextToCI()
     }
 
 

--- a/fastlane/Helpers/Build.swift
+++ b/fastlane/Helpers/Build.swift
@@ -8,6 +8,23 @@
 
 enum Build {
 
+    static func saveBuildContextToCI() {
+        switch Constant.platform {
+        case .bitriseIO:
+            let ipaPath = laneContext()["IPA_OUTPUT_PATH"]
+            let dsymPath = laneContext()["DSYM_OUTPUT_PATH"]
+            let buildNumber = laneContext()["BUILD_NUMBER"]
+
+            sh(command: "echo IPA_OUTPUT_PATH=\(ipaPath ?? "") >> $GITHUB_ENV")
+            sh(command: "echo DSYM_OUTPUT_PATH=\(dsymPath ?? "") >> $GITHUB_ENV")
+            sh(command: "echo BUILD_NUMBER=\(buildNumber ?? "") >> $GITHUB_ENV")
+            sh(command: "echo VERSION_NUMBER=\(Version.versionNumber) >> $GITHUB_ENV")
+        case .gitHubAction:
+            sh(command: "envman add --key BUILD_PATH --value '\(Constant.outputPath)'")
+        default: break
+        }
+    }
+
     static func adHoc(environment: Constant.Environment) {
         build(environment: environment, type: .adHoc)
     }

--- a/fastlane/Helpers/Build.swift
+++ b/fastlane/Helpers/Build.swift
@@ -8,22 +8,7 @@
 
 enum Build {
 
-    static func saveBuildContextToCI() {
-        switch Constant.platform {
-        case .gitHubAction:
-            let ipaPath = laneContext()["IPA_OUTPUT_PATH"]
-            let dsymPath = laneContext()["DSYM_OUTPUT_PATH"]
-            let buildNumber = laneContext()["BUILD_NUMBER"]
-
-            sh(command: "echo IPA_OUTPUT_PATH=\(ipaPath ?? "") >> $GITHUB_ENV")
-            sh(command: "echo DSYM_OUTPUT_PATH=\(dsymPath ?? "") >> $GITHUB_ENV")
-            sh(command: "echo BUILD_NUMBER=\(buildNumber ?? "") >> $GITHUB_ENV")
-            sh(command: "echo VERSION_NUMBER=\(Version.versionNumber) >> $GITHUB_ENV")
-        case .bitriseIO:
-            sh(command: "envman add --key BUILD_PATH --value '\(Constant.outputPath)'")
-        default: break
-        }
-    }
+    // MARK: Build the application
 
     static func adHoc(environment: Constant.Environment) {
         build(environment: environment, type: .adHoc)
@@ -32,6 +17,27 @@ enum Build {
     static func appStore() {
         build(environment: .production, type: .appStore)
     }
+
+    // MARK: Save the build context
+
+    static func saveBuildContextToCI() {
+        switch Constant.platform {
+        case .gitHubActions:
+            let ipaPath = laneContext()["IPA_OUTPUT_PATH"]
+            let dsymPath = laneContext()["DSYM_OUTPUT_PATH"]
+            let buildNumber = laneContext()["BUILD_NUMBER"]
+
+            sh(command: "echo IPA_OUTPUT_PATH=\(ipaPath ?? "") >> $GITHUB_ENV")
+            sh(command: "echo DSYM_OUTPUT_PATH=\(dsymPath ?? "") >> $GITHUB_ENV")
+            sh(command: "echo BUILD_NUMBER=\(buildNumber ?? "") >> $GITHUB_ENV")
+            sh(command: "echo VERSION_NUMBER=\(Version.versionNumber) >> $GITHUB_ENV")
+        case .bitrise:
+            sh(command: "envman add --key BUILD_PATH --value '\(Constant.outputPath)'")
+        default: break
+        }
+    }
+
+    // MARK: Private
 
     static private func build(
         environment: Constant.Environment,

--- a/fastlane/Helpers/Build.swift
+++ b/fastlane/Helpers/Build.swift
@@ -10,7 +10,7 @@ enum Build {
 
     static func saveBuildContextToCI() {
         switch Constant.platform {
-        case .bitriseIO:
+        case .gitHubAction:
             let ipaPath = laneContext()["IPA_OUTPUT_PATH"]
             let dsymPath = laneContext()["DSYM_OUTPUT_PATH"]
             let buildNumber = laneContext()["BUILD_NUMBER"]
@@ -19,7 +19,7 @@ enum Build {
             sh(command: "echo DSYM_OUTPUT_PATH=\(dsymPath ?? "") >> $GITHUB_ENV")
             sh(command: "echo BUILD_NUMBER=\(buildNumber ?? "") >> $GITHUB_ENV")
             sh(command: "echo VERSION_NUMBER=\(Version.versionNumber) >> $GITHUB_ENV")
-        case .gitHubAction:
+        case .bitriseIO:
             sh(command: "envman add --key BUILD_PATH --value '\(Constant.outputPath)'")
         default: break
         }

--- a/fastlane/Helpers/EnvironmentParser.swift
+++ b/fastlane/Helpers/EnvironmentParser.swift
@@ -1,0 +1,20 @@
+//
+//  EnvironmentParser.swift
+//  FastlaneRunner
+//
+//  Created by Su T. on 09/11/2022.
+//  Copyright © 2022 Nimble. All rights reserved.
+//
+
+import Foundation
+
+enum EnvironmentParser {
+
+    static func bool(key: String) -> Bool {
+        string(key: key) == "true"
+    }
+
+    static func string(key: String) -> String {
+        environmentVariable(get: .userDefined(key))
+    }
+}

--- a/fastlane/swift/FastlaneSwiftRunner/FastlaneSwiftRunner.xcodeproj/project.pbxproj
+++ b/fastlane/swift/FastlaneSwiftRunner/FastlaneSwiftRunner.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		8B9386D728E2A8630045D709 /* Symbol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9386D628E2A8630045D709 /* Symbol.swift */; };
 		90C4D77B28DDC86800E06274 /* Build.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C4D77A28DDC86800E06274 /* Build.swift */; };
 		90C4D77D28E0AB2A00E06274 /* Distribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C4D77C28E0AB2A00E06274 /* Distribution.swift */; };
+		90DA64BD291BC7F400BABF4D /* EnvironmentParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90DA64BC291BC7F400BABF4D /* EnvironmentParser.swift */; };
 		90F4F4CB28E4455C008BDAE5 /* AppStoreAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F4F4CA28E4455C008BDAE5 /* AppStoreAuthentication.swift */; };
 		B302067B1F5E3E9000DE6EBD /* SnapshotfileProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30206741F5E3E9000DE6EBD /* SnapshotfileProtocol.swift */; };
 		B302067C1F5E3E9000DE6EBD /* GymfileProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30206751F5E3E9000DE6EBD /* GymfileProtocol.swift */; };
@@ -80,6 +81,7 @@
 		8B9386D628E2A8630045D709 /* Symbol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Symbol.swift; path = ../../Helpers/Symbol.swift; sourceTree = "<group>"; };
 		90C4D77A28DDC86800E06274 /* Build.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Build.swift; path = ../../Helpers/Build.swift; sourceTree = "<group>"; };
 		90C4D77C28E0AB2A00E06274 /* Distribution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Distribution.swift; path = ../../Helpers/Distribution.swift; sourceTree = "<group>"; };
+		90DA64BC291BC7F400BABF4D /* EnvironmentParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EnvironmentParser.swift; path = ../../Helpers/EnvironmentParser.swift; sourceTree = "<group>"; };
 		90F4F4CA28E4455C008BDAE5 /* AppStoreAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppStoreAuthentication.swift; path = ../../Helpers/AppStoreAuthentication.swift; sourceTree = "<group>"; };
 		B30206741F5E3E9000DE6EBD /* SnapshotfileProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SnapshotfileProtocol.swift; path = ../SnapshotfileProtocol.swift; sourceTree = "<group>"; };
 		B30206751F5E3E9000DE6EBD /* GymfileProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GymfileProtocol.swift; path = ../GymfileProtocol.swift; sourceTree = "<group>"; };
@@ -130,12 +132,13 @@
 			isa = PBXGroup;
 			children = (
 				90F4F4CA28E4455C008BDAE5 /* AppStoreAuthentication.swift */,
-				1C2D0FA628E457D10059FF5A /* Test.swift */,
 				90C4D77A28DDC86800E06274 /* Build.swift */,
 				90C4D77C28E0AB2A00E06274 /* Distribution.swift */,
+				90DA64BC291BC7F400BABF4D /* EnvironmentParser.swift */,
 				8B92CD0A28DC63E000A3FF05 /* Keychain.swift */,
 				8B92CD0328DC62D200A3FF05 /* Match.swift */,
 				8B9386D628E2A8630045D709 /* Symbol.swift */,
+				1C2D0FA628E457D10059FF5A /* Test.swift */,
 				1C2D0FA428E4512E0059FF5A /* Version.swift */,
 			);
 			name = Helpers;
@@ -315,6 +318,7 @@
 				D5BAFD121F7DAAFC0030B324 /* ArgumentProcessor.swift in Sources */,
 				B302067C1F5E3E9000DE6EBD /* GymfileProtocol.swift in Sources */,
 				B302067B1F5E3E9000DE6EBD /* SnapshotfileProtocol.swift in Sources */,
+				90DA64BD291BC7F400BABF4D /* EnvironmentParser.swift in Sources */,
 				D55B28C31F6C588300DC42C5 /* Deliverfile.swift in Sources */,
 				90C4D77D28E0AB2A00E06274 /* Distribution.swift in Sources */,
 				D5A7C4901F7C4DAF00A91DE6 /* Fastfile.swift in Sources */,


### PR DESCRIPTION
#382 

## What happened

Support uploading build and dSYM files to build artifacts of CI/CD platforms.
 
## Insight

- Create `EnvironmentParser` to read any environment variable by key; it supports getting `bool` and `string`.
  - In ruby, we use `ENV["KEY_NAME"]`.
  - In Swift, it becomes `environmentVariable(get: "KEY_NAME")`.
- Create a `platform` in `Constant` to determine which platform is running on.
- Also update Secret's variables by retrieve from `EnvironmentParser` based on the key:
  - `KEYCHAIN_PASSWORD`
  - `FIREBASE_CLI_TOKEN`
  - `APPSTORE_CONNECT_API_KEY`

## Proof Of Work

### GITHUB ACTIONS

![Screen Shot 2022-11-10 at 15 39 10](https://user-images.githubusercontent.com/17830319/201041994-8294fa57-9741-4986-acbc-29020899db9b.png)

![Screen Shot 2022-11-10 at 15 39 19](https://user-images.githubusercontent.com/17830319/201041966-7bd2e858-3b85-4e2f-940f-4f928acc1da0.png)

### BITRISE

<img width="992" alt="Screen Shot 2022-11-10 at 15 19 07" src="https://user-images.githubusercontent.com/17830319/201041227-8dc6dca0-ea5b-44d6-918f-ad911bf41b48.png">
