### PR TITLE
[#423] Update a specific name for deploying staging build to firebase workflow

### DIFF
--- a/.github/workflows/deploy_production_firebase.yml
+++ b/.github/workflows/deploy_production_firebase.yml
@@ -1,4 +1,4 @@
-name: Deploy Release Build To Firebase
+name: Deploy Production Build To Firebase
 
 # SECRETS needed:
 ### SSH_PRIVATE_KEY for Match Repo

--- a/.github/workflows/deploy_staging_firebase.yml
+++ b/.github/workflows/deploy_staging_firebase.yml
@@ -1,4 +1,4 @@
-name: Deploy Build To Firebase
+name: Deploy Staging Build To Firebase
 
 # SECRETS needed:
 ### SSH_PRIVATE_KEY for Match Repo


### PR DESCRIPTION
https://github.com/nimblehq/ios-templates/issues/423

## What happened

- Updated name from `deploy_Release_Firebase` to `deploy_production_firebase` for deploying production build to firebase workflow.
- Updated name from `deploy_Firbase` to `deploy_staging_firebase` for deploying staging build to firebase workflow.
- Updated their descriptions too.

## Insight

N/A
 
## Proof Of Work
![Screenshot 2023-01-11 at 14 41 15](https://user-images.githubusercontent.com/25881847/211746567-6e43384a-8519-4654-9674-54ea0245f7ce.png)


