### PR TITLE
[#432] [Bug] Fix: DeliverableConstants.rb does not exist

### DIFF
--- a/deliverable_setup.sh
+++ b/deliverable_setup.sh
@@ -12,9 +12,9 @@ else
 fi
 echo "✅  Completed"
 
-read -n1 -p "Do you want to set up Deliverable Constants values? (Can be edited later) [Y/n]:" confirm
+read -n1 -p "Do you want to set up Constants values? (Can be edited later) [Y/n]:" confirm
 if ! echo $confirm | grep '^[Yy]\?$'; then
     echo "✅  Completed"
 else
-    open -a Xcode fastlane/Constants/DeliverableConstants.rb
+    open -a Xcode fastlane/Constants/Constant.swift
 fi


### PR DESCRIPTION
- #432 

## What happened

- Because the iOS template uses Fastlane Swift, the DeliverableConstants.rb was replaced with Constant.swift. We need to update deliverable_setup.sh to open Constants.swift instead of DeliverableConstants.rb
 
## Insight

- Update deliverable_setup.sh files: Change from opening DeliverableConstants.rb file to Constant.swift file
 
## Proof Of Work

https://user-images.githubusercontent.com/24598204/217412798-c5cec2f3-caa7-4844-b10f-dd9de5f79511.mov

