### PR TITLE
[#438] [Bug] Fix: Remove Workspace.swift when make.sh success

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -181,6 +181,7 @@ echo "Remove tuist files"
 rm -rf .tuist-version
 rm -rf tuist
 rm -rf Project.swift
+rm -rf Workspace.swift
 
 # Remove script files and git/index
 echo "Remove script files and git/index"


### PR DESCRIPTION
- #438 

## What happened

- After make.sh runs successfully, we should remove Workspace.swift as well as Project.swift, which Tuist does not reuse.
 
## Insight

- Update make.sh: add command to remove Workspace.swift
 
## Proof Of Work

https://user-images.githubusercontent.com/24598204/217414341-3adff36d-4ad2-48d3-8f24-9f4e8e21136c.mov

