### PR TITLE
[Chore] Update Pods dependencies

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -7,9 +7,7 @@ def testing_pods
   pod 'Nimble'
   pod 'RxNimble', subspecs: ['RxBlocking', 'RxTest']
   pod 'RxSwift'
-  # TODO: Remove or update the version of `1.8.0` to the newest version (not 1.8.1) when init a new project.
-  # Currently, there is a bug on `1.8.1` - the newest version.
-  pod 'Sourcery', '1.8.0'
+  pod 'Sourcery'
   pod 'SwiftFormat/CLI'
 end
 
@@ -32,7 +30,7 @@ target '{PROJECT_NAME}' do
   pod 'IQKeyboardManagerSwift'
   pod 'NimbleExtension', :git => 'https://github.com/nimblehq/NimbleExtension', :branch => 'master'
   pod 'R.swift'
-  pod 'Resolver' # Needs Cocoapods on iOS 11 to support Resolver
+  pod 'Factory'
 
   # Development
   pod 'SwiftLint'


### PR DESCRIPTION
## What happened 👀

In Podfile:
- Removed the fixed version of [Sourcery](https://github.com/krzysztofzablocki/Sourcery) (1.8.0)
- Replaced [Resolver](https://github.com/hmlongco/Resolver) by [Factory](https://github.com/hmlongco/Factory)

## Insight 📝

- For Sourcery, we had an issue with version `1.8.1`. Now the latest version is `2.0.1`, it added more features and also improved the performance (20%). So it's better to use the latest version.
- For the replacement of Resolver, this is the note from the author of Resolver:
> Note: Later in 2022 Resolver will be deprecated and replaced by my new dependency injection system, [Factory](https://github.com/hmlongco/Factory). Factory is compile-time safe and is smaller, lighter, and faster than Resolver. As good as Resolver is, Factory is better.

So it's time to use Factory.

## Proof Of Work 📹

CI/CD should be succeeded
