### PR TITLE
[#330] Modify signing automatically when generating a project

### DIFF
--- a/.github/workflows/test_upload_build_to_test_flight.yml
+++ b/.github/workflows/test_upload_build_to_test_flight.yml
@@ -56,7 +56,7 @@ jobs:
       run: bundle exec fastlane setUpTestProject
 
     - name: Update Provision Profile
-      run: bundle exec fastlane updateProvisionSettings
+      run: bundle exec fastlane syncAppStoreCodeSigning
       env:
         MATCH_PASSWORD: ${{ secrets.MATCH_PASS }}
 

--- a/.github/workflows/test_upload_build_to_test_flight.yml
+++ b/.github/workflows/test_upload_build_to_test_flight.yml
@@ -7,6 +7,7 @@ name: Test Upload Build to TestFlight
 ### API_KEY_ID
 ### ISSUER_ID
 ### APPSTORE_CONNECT_API_KEY
+### TEAM_ID
 
 on:
   pull_request
@@ -51,6 +52,7 @@ jobs:
         MATCH_REPO: ${{ secrets.MATCH_REPO }}
         API_KEY_ID: ${{ secrets.API_KEY_ID }}
         ISSUER_ID: ${{ secrets.ISSUER_ID }}
+        TEAM_ID: ${{ secrets.TEAM_ID }}
 
     - name: Set Up Test Project for App Store
       run: bundle exec fastlane setUpTestProject

--- a/fastlane/Constants/Constant.swift
+++ b/fastlane/Constants/Constant.swift
@@ -122,6 +122,14 @@ extension Constant {
 
         var value: String { return rawValue }
         
+        var match: String {
+            switch self {
+            case .development: return "development"
+            case .adHoc: return "adhoc"
+            case .appStore: return "appstore"
+            }
+        }
+        
         var configuration: String {
             switch self {
             case .development: return "Debug"

--- a/fastlane/Constants/Constant.swift
+++ b/fastlane/Constants/Constant.swift
@@ -83,7 +83,12 @@ extension Constant {
 
         var productName: String { "\(Constant.projectName) \(rawValue)".trimmed }
 
-        var scheme: String { "\(Constant.projectName) \(rawValue)".trimmed }
+        var scheme: String {
+            switch self {
+            case .staging: return "\(Constant.projectName) \(rawValue)".trimmed
+            case .production: return Constant.projectName
+            }
+        }
 
         var bundleId: String {
             switch self {

--- a/fastlane/Constants/Constant.swift
+++ b/fastlane/Constants/Constant.swift
@@ -79,7 +79,7 @@ extension Constant {
     enum Environment: String {
 
         case staging = "Staging"
-        case production = ""
+        case production = "Production"
 
         var productName: String { "\(Constant.projectName) \(rawValue)".trimmed }
 
@@ -116,13 +116,29 @@ extension Constant {
 
     enum BuildType: String {
 
+        case development
         case adHoc = "ad-hoc"
         case appStore = "app-store"
 
         var value: String { return rawValue }
-
+        
+        var configuration: String {
+            switch self {
+            case .development: return "Debug"
+            case .adHoc, .appStore: return "Release"
+            }
+        }
+        
+        var codeSignIdentity: String {
+            switch self {
+            case .development: return "iPhone Developer"
+            case .adHoc, . appStore: return "iPhone Distribution"
+            }
+        }
+        
         var method: String {
             switch self {
+            case .development: return "Development"
             case .adHoc: return "AdHoc"
             case .appStore: return "AppStore"
             }

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -12,11 +12,19 @@ class Fastfile: LaneFile {
 
     // MARK: - Code signing
 
-    func syncDevelopmentCodeSigningLane() {
+    func syncDevelopmentStagingCodeSigningLane() {
         desc("Sync the Development match signing for the Staging build")
         Match.syncCodeSigning(
             type: .development,
             appIdentifier: [Constant.stagingBundleId]
+        )
+    }
+    
+    func syncDevelopmentProductionCodeSigningLane() {
+        desc("Sync the Development match signing for the Staging build")
+        Match.syncCodeSigning(
+            type: .development,
+            appIdentifier: [Constant.productionBundleId]
         )
     }
 

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -21,7 +21,7 @@ class Fastfile: LaneFile {
     }
     
     func syncDevelopmentProductionCodeSigningLane() {
-        desc("Sync the Development match signing for the Staging build")
+        desc("Sync the Development match signing for the Production build")
         Match.syncCodeSigning(
             type: .development,
             environment: .production
@@ -88,7 +88,7 @@ class Fastfile: LaneFile {
     }
 
     func buildProductionAndUploadToFirebaseLane() {
-        desc("Build Staging app and upload to Firebase")
+        desc("Build Production app and upload to Firebase")
 
         setAppVersion()
         bumpBuild()

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -145,20 +145,6 @@ class Fastfile: LaneFile {
         )
     }
 
-    func updateProvisionSettingsLane() {
-        desc("Update Provision Profile")
-        syncAppStoreCodeSigningLane()
-        updateCodeSigningSettings(
-            path: Constant.projectPath,
-            useAutomaticSigning: .userDefined(false),
-            teamId: .userDefined(EnvironmentParser.string(key: "sigh_\(Constant.productionBundleId)_appstore_team-id")),
-            codeSignIdentity: .userDefined("iPhone Distribution"),
-            profileName: .userDefined(EnvironmentParser.string(
-                key: "sigh_\(Constant.productionBundleId)_appstore_profile-name"
-            ))
-        )
-    }
-
     func setUpTestProjectLane() {
         desc("Disable Exempt Encryption")
         Test.disableExemptEncryption()

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -16,7 +16,7 @@ class Fastfile: LaneFile {
         desc("Sync the Development match signing for the Staging build")
         Match.syncCodeSigning(
             type: .development,
-            appIdentifier: [Constant.stagingBundleId]
+            environment: .staging
         )
     }
     
@@ -24,7 +24,7 @@ class Fastfile: LaneFile {
         desc("Sync the Development match signing for the Staging build")
         Match.syncCodeSigning(
             type: .development,
-            appIdentifier: [Constant.productionBundleId]
+            environment: .production
         )
     }
 
@@ -32,7 +32,7 @@ class Fastfile: LaneFile {
         desc("Sync the Ad Hoc match signing for the Staging build")
         Match.syncCodeSigning(
             type: .adHoc,
-            appIdentifier: [Constant.stagingBundleId]
+            environment: .staging
         )
     }
 
@@ -40,7 +40,7 @@ class Fastfile: LaneFile {
         desc("Sync the Ad Hoc match signing for the Production build")
         Match.syncCodeSigning(
             type: .adHoc,
-            appIdentifier: [Constant.productionBundleId]
+            environment: .production
         )
     }
 
@@ -48,7 +48,7 @@ class Fastfile: LaneFile {
         desc("Sync the App Store match signing for the Production build")
         Match.syncCodeSigning(
             type: .appStore,
-            appIdentifier: [Constant.productionBundleId]
+            environment: .production
         )
     }
 
@@ -170,8 +170,8 @@ class Fastfile: LaneFile {
             teamId: .userDefined(Constant.teamId)
         )
 
-        Match.syncCodeSigning(type: .development, appIdentifier: [], isForce: true)
-        Match.syncCodeSigning(type: .adHoc, appIdentifier: [], isForce: true)
+        Match.syncCodeSigning(type: .development, environment: .staging, isForce: true)
+        Match.syncCodeSigning(type: .adHoc, environment: .staging, isForce: true)
     }
 
     // MARK: - Utilities

--- a/fastlane/Helpers/Build.swift
+++ b/fastlane/Helpers/Build.swift
@@ -52,7 +52,7 @@ enum Build {
             exportMethod: .userDefined(type.value),
             exportOptions: .userDefined([
                 "provisioningProfiles": [
-                    environment.bundleId: "match \(type.method) \(environment.bundleId)"
+                    environment.bundleId: Match.createProfileName(type: type, environment: environment)
                 ]
             ]),
             buildPath: .userDefined(Constant.buildPath),

--- a/fastlane/Helpers/Match.swift
+++ b/fastlane/Helpers/Match.swift
@@ -66,13 +66,13 @@ extension Match {
     }
     
     enum MatchType: String {
-        
+
         case development
         case adHoc = "adhoc"
         case appStore = "appstore"
-        
+
         var value: String { return rawValue }
-        
+
         var method: String {
             switch self {
             case .development: return "Development"

--- a/fastlane/Helpers/Match.swift
+++ b/fastlane/Helpers/Match.swift
@@ -12,7 +12,7 @@ enum Match {
         if isCi() {
             Keychain.create()
             match(
-                type: type.value,
+                type: type.match,
                 readonly: .userDefined(!isForce),
                 appIdentifier: [environment.bundleId],
                 username: .userDefined(Constant.userName),
@@ -24,7 +24,7 @@ enum Match {
             )
         } else {
             match(
-                type: type.value,
+                type: type.match,
                 readonly: .userDefined(!isForce),
                 appIdentifier: [environment.bundleId],
                 username: .userDefined(Constant.userName),

--- a/fastlane/Helpers/Match.swift
+++ b/fastlane/Helpers/Match.swift
@@ -32,8 +32,8 @@ enum Match {
                 gitUrl: Constant.matchURL,
                 force: .userDefined(isForce)
             )
-            updateCodeSigning(type: type, appIdentifier: appIdentifier)
         }
+        updateCodeSigning(type: type, appIdentifier: appIdentifier)
     }
     
     static func updateCodeSigning(type: MatchType, appIdentifier: [String]) {

--- a/fastlane/Helpers/Match.swift
+++ b/fastlane/Helpers/Match.swift
@@ -7,7 +7,7 @@
 //
 
 enum Match {
-    
+
     static func syncCodeSigning(type: MatchType, environment: Environment, isForce: Bool = false) {
         if isCi() {
             Keychain.create()

--- a/fastlane/Helpers/Match.swift
+++ b/fastlane/Helpers/Match.swift
@@ -40,34 +40,34 @@ enum Match {
         // Update Code signing from automatic to manual
         switch type {
         case .development:
-            updateCodeSigningSettings(
-                path: Constant.projectPath,
-                useAutomaticSigning: .userDefined(false),
-                targets: .userDefined([Constant.projectName]),
-                buildConfigurations: .userDefined(["Debug Staging"]),
-                codeSignIdentity: .userDefined("iPhone Developer"),
-                profileName: .userDefined("match Development \(Constant.stagingBundleId)")
-            )
-        case .adHoc:
             if appIdentifier.first == Constant.productionBundleId {
                 updateCodeSigningSettings(
                     path: Constant.projectPath,
                     useAutomaticSigning: .userDefined(false),
                     targets: .userDefined([Constant.projectName]),
                     buildConfigurations: .userDefined(["Debug Production"]),
-                    codeSignIdentity: .userDefined("iPhone Distribution"),
-                    profileName: .userDefined("match AdHoc \(Constant.productionBundleId)")
+                    codeSignIdentity: .userDefined("iPhone Developer"),
+                    profileName: .userDefined("match \(type.method) \(Constant.productionBundleId)")
                 )
             } else {
                 updateCodeSigningSettings(
                     path: Constant.projectPath,
                     useAutomaticSigning: .userDefined(false),
                     targets: .userDefined([Constant.projectName]),
-                    buildConfigurations: .userDefined(["Release Staging"]),
-                    codeSignIdentity: .userDefined("iPhone Distribution"),
-                    profileName: .userDefined("match AdHoc \(Constant.stagingBundleId)")
+                    buildConfigurations: .userDefined(["Debug Staging"]),
+                    codeSignIdentity: .userDefined("iPhone Developer"),
+                    profileName: .userDefined("match \(type.method) \(Constant.stagingBundleId)")
                 )
             }
+        case .adHoc:
+            updateCodeSigningSettings(
+                path: Constant.projectPath,
+                useAutomaticSigning: .userDefined(false),
+                targets: .userDefined([Constant.projectName]),
+                buildConfigurations: .userDefined(["Release Staging"]),
+                codeSignIdentity: .userDefined("iPhone Distribution"),
+                profileName: .userDefined("match \(type.method) \(Constant.stagingBundleId)")
+            )
         case .appStore:
             updateCodeSigningSettings(
                 path: Constant.projectPath,
@@ -75,7 +75,7 @@ enum Match {
                 targets: .userDefined([Constant.projectName]),
                 buildConfigurations: .userDefined(["Release Production"]),
                 codeSignIdentity: .userDefined("iPhone Distribution"),
-                profileName: .userDefined("match AppStore \(Constant.productionBundleId)")
+                profileName: .userDefined("match \(type.method) \(Constant.productionBundleId)")
             )
         }
     }
@@ -90,5 +90,13 @@ extension Match {
         case appStore = "appstore"
 
         var value: String { return rawValue }
+        
+        var method: String {
+            switch self {
+            case .development: return "Development"
+            case .adHoc: return "AdHoc"
+            case .appStore: return "AppStore"
+            }
+        }
     }
 }

--- a/fastlane/Helpers/Match.swift
+++ b/fastlane/Helpers/Match.swift
@@ -44,9 +44,9 @@ enum Match {
                 path: Constant.projectPath,
                 useAutomaticSigning: .userDefined(false),
                 targets: .userDefined([Constant.projectName]),
-                buildConfigurations: .userDefined(["Release Staging"]),
+                buildConfigurations: .userDefined(["Debug Staging"]),
                 codeSignIdentity: .userDefined("iPhone Developer"),
-                profileName: .userDefined("match AdHoc \(Constant.stagingBundleId)")
+                profileName: .userDefined("match Development \(Constant.stagingBundleId)")
             )
         case .adHoc:
             if appIdentifier.first == Constant.productionBundleId {

--- a/fastlane/Helpers/Match.swift
+++ b/fastlane/Helpers/Match.swift
@@ -41,7 +41,6 @@ enum Match {
         updateCodeSigningSettings(
             path: Constant.projectPath,
             useAutomaticSigning: .userDefined(false),
-            teamId: .userDefined(Constant.teamId),
             targets: .userDefined([Constant.projectName]),
             buildConfigurations: .userDefined([Self.createBuildConfiguration(type: type, environment: environment)]),
             codeSignIdentity: .userDefined(type.codeSignIdentity),

--- a/fastlane/Helpers/Match.swift
+++ b/fastlane/Helpers/Match.swift
@@ -7,7 +7,7 @@
 //
 
 enum Match {
-
+    
     static func syncCodeSigning(type: MatchType, environment: Environment, isForce: Bool = false) {
         if isCi() {
             Keychain.create()
@@ -41,13 +41,11 @@ enum Match {
         updateCodeSigningSettings(
             path: Constant.projectPath,
             useAutomaticSigning: .userDefined(false),
-            teamId: .userDefined(EnvironmentParser.string(
-                key: "sigh_\(environment.bundleId)_\(type.rawValue)_team-id"
-            )),
+            teamId: .userDefined(Constant.teamId),
+            targets: .userDefined([Constant.projectName]),
+            buildConfigurations: .userDefined(["\(type.buildConfiguration) \(environment.rawValue)"]),
             codeSignIdentity: .userDefined(type.codeSignIdentity),
-            profileName: .userDefined(EnvironmentParser.string(
-                key: "sigh_\(environment.bundleId)_\(type.rawValue)_profile-name"
-            ))
+            profileName: .userDefined("match \(type.method) \(environment.bundleId)")
         )
     }
 }
@@ -55,6 +53,7 @@ enum Match {
 extension Match {
     
     enum Environment: String {
+        
         case staging = "Staging"
         case production = "Production"
         
@@ -65,13 +64,13 @@ extension Match {
             }
         }
     }
-
+    
     enum MatchType: String {
-
+        
         case development
         case adHoc = "adhoc"
         case appStore = "appstore"
-
+        
         var value: String { return rawValue }
         
         var method: String {
@@ -88,7 +87,6 @@ extension Match {
             case .adHoc, .appStore: return "Release"
             }
         }
-        
         var codeSignIdentity: String {
             switch self {
             case .development: return "iPhone Developer"

--- a/fastlane/Helpers/Match.swift
+++ b/fastlane/Helpers/Match.swift
@@ -8,7 +8,7 @@
 
 enum Match {
 
-    static func syncCodeSigning(type: MatchType, environment: Environment, isForce: Bool = false) {
+    static func syncCodeSigning(type: Constant.BuildType, environment: Constant.Environment, isForce: Bool = false) {
         if isCi() {
             Keychain.create()
             match(
@@ -36,62 +36,24 @@ enum Match {
         updateCodeSigning(type: type, environment: environment)
     }
     
-    static func updateCodeSigning(type: MatchType, environment: Environment) {
+    static func updateCodeSigning(type: Constant.BuildType, environment: Constant.Environment) {
         // Update Code signing from automatic to manual
         updateCodeSigningSettings(
             path: Constant.projectPath,
             useAutomaticSigning: .userDefined(false),
             teamId: .userDefined(Constant.teamId),
             targets: .userDefined([Constant.projectName]),
-            buildConfigurations: .userDefined(["\(type.buildConfiguration) \(environment.rawValue)"]),
+            buildConfigurations: .userDefined([Self.createBuildConfiguration(type: type, environment: environment)]),
             codeSignIdentity: .userDefined(type.codeSignIdentity),
-            profileName: .userDefined("match \(type.method) \(environment.bundleId)")
+            profileName: .userDefined(Self.createProfileName(type: type, environment: environment))
         )
     }
-}
-
-extension Match {
     
-    enum Environment: String {
-        
-        case staging = "Staging"
-        case production = "Production"
-        
-        var bundleId: String {
-            switch self {
-            case .staging: return Constant.stagingBundleId
-            case .production: return Constant.productionBundleId
-            }
-        }
+    static func createBuildConfiguration(type: Constant.BuildType, environment: Constant.Environment) -> String {
+        "\(type.configuration) \(environment.rawValue)"
     }
     
-    enum MatchType: String {
-
-        case development
-        case adHoc = "adhoc"
-        case appStore = "appstore"
-
-        var value: String { return rawValue }
-
-        var method: String {
-            switch self {
-            case .development: return "Development"
-            case .adHoc: return "AdHoc"
-            case .appStore: return "AppStore"
-            }
-        }
-        
-        var buildConfiguration: String {
-            switch self {
-            case .development: return "Debug"
-            case .adHoc, .appStore: return "Release"
-            }
-        }
-        var codeSignIdentity: String {
-            switch self {
-            case .development: return "iPhone Developer"
-            case .adHoc, . appStore: return "iPhone Distribution"
-            }
-        }
+    static func createProfileName(type: Constant.BuildType, environment: Constant.Environment) -> String {
+        "match \(type.method) \(environment.bundleId)"
     }
 }

--- a/fastlane/Helpers/Match.swift
+++ b/fastlane/Helpers/Match.swift
@@ -41,10 +41,13 @@ enum Match {
         updateCodeSigningSettings(
             path: Constant.projectPath,
             useAutomaticSigning: .userDefined(false),
-            targets: .userDefined([Constant.projectName]),
-            buildConfigurations: .userDefined(["\(type.buildConfiguration) \(environment.rawValue)"]),
+            teamId: .userDefined(EnvironmentParser.string(
+                key: "sigh_\(Constant.productionBundleId)_\(type.rawValue)_team-id"
+            )),
             codeSignIdentity: .userDefined(type.codeSignIdentity),
-            profileName: .userDefined("match \(type.method) \(environment.bundleId)")
+            profileName: .userDefined(EnvironmentParser.string(
+                key: "sigh_\(environment.bundleId)_\(type.rawValue)_profile-name"
+            ))
         )
     }
 }

--- a/fastlane/Helpers/Match.swift
+++ b/fastlane/Helpers/Match.swift
@@ -42,7 +42,7 @@ enum Match {
             path: Constant.projectPath,
             useAutomaticSigning: .userDefined(false),
             teamId: .userDefined(EnvironmentParser.string(
-                key: "sigh_\(Constant.productionBundleId)_\(type.rawValue)_team-id"
+                key: "sigh_\(environment.bundleId)_\(type.rawValue)_team-id"
             )),
             codeSignIdentity: .userDefined(type.codeSignIdentity),
             profileName: .userDefined(EnvironmentParser.string(

--- a/fastlane/Helpers/Match.swift
+++ b/fastlane/Helpers/Match.swift
@@ -41,6 +41,7 @@ enum Match {
         updateCodeSigningSettings(
             path: Constant.projectPath,
             useAutomaticSigning: .userDefined(false),
+            teamId: .userDefined(Constant.teamId),
             targets: .userDefined([Constant.projectName]),
             buildConfigurations: .userDefined([Self.createBuildConfiguration(type: type, environment: environment)]),
             codeSignIdentity: .userDefined(type.codeSignIdentity),

--- a/fastlane/Helpers/Match.swift
+++ b/fastlane/Helpers/Match.swift
@@ -32,6 +32,51 @@ enum Match {
                 gitUrl: Constant.matchURL,
                 force: .userDefined(isForce)
             )
+            updateCodeSigning(type: type, appIdentifier: appIdentifier)
+        }
+    }
+    
+    static func updateCodeSigning(type: MatchType, appIdentifier: [String]) {
+        // Update Code signing from automatic to manual
+        switch type {
+        case .development:
+            updateCodeSigningSettings(
+                path: Constant.projectPath,
+                useAutomaticSigning: .userDefined(false),
+                targets: .userDefined([Constant.projectName]),
+                buildConfigurations: .userDefined(["Release Staging"]),
+                codeSignIdentity: .userDefined("iPhone Developer"),
+                profileName: .userDefined("match AdHoc \(Constant.stagingBundleId)")
+            )
+        case .adHoc:
+            if appIdentifier.first == Constant.productionBundleId {
+                updateCodeSigningSettings(
+                    path: Constant.projectPath,
+                    useAutomaticSigning: .userDefined(false),
+                    targets: .userDefined([Constant.projectName]),
+                    buildConfigurations: .userDefined(["Debug Production"]),
+                    codeSignIdentity: .userDefined("iPhone Distribution"),
+                    profileName: .userDefined("match AdHoc \(Constant.productionBundleId)")
+                )
+            } else {
+                updateCodeSigningSettings(
+                    path: Constant.projectPath,
+                    useAutomaticSigning: .userDefined(false),
+                    targets: .userDefined([Constant.projectName]),
+                    buildConfigurations: .userDefined(["Release Staging"]),
+                    codeSignIdentity: .userDefined("iPhone Distribution"),
+                    profileName: .userDefined("match AdHoc \(Constant.stagingBundleId)")
+                )
+            }
+        case .appStore:
+            updateCodeSigningSettings(
+                path: Constant.projectPath,
+                useAutomaticSigning: .userDefined(false),
+                targets: .userDefined([Constant.projectName]),
+                buildConfigurations: .userDefined(["Release Production"]),
+                codeSignIdentity: .userDefined("iPhone Distribution"),
+                profileName: .userDefined("match AppStore \(Constant.productionBundleId)")
+            )
         }
     }
 }

--- a/set_up_test_testflight.sh
+++ b/set_up_test_testflight.sh
@@ -8,7 +8,7 @@ readonly CONSTANT_MATCH_REPO="git@github.com:{organization}\/{repo}.git"
 readonly WORKING_DIR=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 MATCH_REPO_ESCAPED=$(echo "${MATCH_REPO//\//\\\/}")
 
-LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_TEAM_ID/4TWS7E2EPE/g" {} +
+LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_TEAM_ID/$TEAM_ID/g" {} +
 LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_API_KEY_ID/$API_KEY_ID/g" {} +
 LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_ISSUER_ID/$ISSUER_ID/g" {} +
 LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_MATCH_REPO/$MATCH_REPO_ESCAPED/g" {} +

--- a/set_up_test_testflight.sh
+++ b/set_up_test_testflight.sh
@@ -1,5 +1,6 @@
 echo "import('./Tests/Fastfile')" | cat - fastlane/Fastfile | tee fastlane/Fastfile &> /dev/null
 
+readonly CONSTANT_TEAM_ID="<#teamId#>"
 readonly CONSTANT_API_KEY_ID="<#API_KEY_ID#>"
 readonly CONSTANT_ISSUER_ID="<#ISSUER_ID#>"
 readonly CONSTANT_MATCH_REPO="git@github.com:{organization}\/{repo}.git"
@@ -7,6 +8,7 @@ readonly CONSTANT_MATCH_REPO="git@github.com:{organization}\/{repo}.git"
 readonly WORKING_DIR=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 MATCH_REPO_ESCAPED=$(echo "${MATCH_REPO//\//\\\/}")
 
+LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_TEAM_ID/4TWS7E2EPE/g" {} +
 LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_API_KEY_ID/$API_KEY_ID/g" {} +
 LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_ISSUER_ID/$ISSUER_ID/g" {} +
 LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_MATCH_REPO/$MATCH_REPO_ESCAPED/g" {} +

--- a/set_up_test_testflight.sh
+++ b/set_up_test_testflight.sh
@@ -1,3 +1,4 @@
+readonly CONSTANT_TEAM_ID="<#teamId#>"
 readonly CONSTANT_API_KEY_ID="<#API_KEY_ID#>"
 readonly CONSTANT_ISSUER_ID="<#ISSUER_ID#>"
 readonly CONSTANT_MATCH_REPO="git@github.com:{organization}\/{repo}.git"
@@ -5,6 +6,7 @@ readonly CONSTANT_MATCH_REPO="git@github.com:{organization}\/{repo}.git"
 readonly WORKING_DIR=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 MATCH_REPO_ESCAPED=$(echo "${MATCH_REPO//\//\\\/}")
 
+LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_TEAM_ID/4TWS7E2EPE/g" {} +
 LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_API_KEY_ID/$API_KEY_ID/g" {} +
 LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_ISSUER_ID/$ISSUER_ID/g" {} +
 LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_MATCH_REPO/$MATCH_REPO_ESCAPED/g" {} +

--- a/set_up_test_testflight.sh
+++ b/set_up_test_testflight.sh
@@ -1,5 +1,3 @@
-echo "import('./Tests/Fastfile')" | cat - fastlane/Fastfile | tee fastlane/Fastfile &> /dev/null
-
 readonly CONSTANT_TEAM_ID="<#teamId#>"
 readonly CONSTANT_API_KEY_ID="<#API_KEY_ID#>"
 readonly CONSTANT_ISSUER_ID="<#ISSUER_ID#>"
@@ -8,7 +6,7 @@ readonly CONSTANT_MATCH_REPO="git@github.com:{organization}\/{repo}.git"
 readonly WORKING_DIR=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 MATCH_REPO_ESCAPED=$(echo "${MATCH_REPO//\//\\\/}")
 
-LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_TEAM_ID/$TEAM_ID/g" {} +
+LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_TEAM_ID/4TWS7E2EPE/g" {} +
 LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_API_KEY_ID/$API_KEY_ID/g" {} +
 LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_ISSUER_ID/$ISSUER_ID/g" {} +
 LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_MATCH_REPO/$MATCH_REPO_ESCAPED/g" {} +

--- a/set_up_test_testflight.sh
+++ b/set_up_test_testflight.sh
@@ -6,7 +6,7 @@ readonly CONSTANT_MATCH_REPO="git@github.com:{organization}\/{repo}.git"
 readonly WORKING_DIR=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 MATCH_REPO_ESCAPED=$(echo "${MATCH_REPO//\//\\\/}")
 
-LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_TEAM_ID/4TWS7E2EPE/g" {} +
+LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_TEAM_ID/$TEAM_ID/g" {} +
 LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_API_KEY_ID/$API_KEY_ID/g" {} +
 LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_ISSUER_ID/$ISSUER_ID/g" {} +
 LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_MATCH_REPO/$MATCH_REPO_ESCAPED/g" {} +

--- a/set_up_test_testflight.sh
+++ b/set_up_test_testflight.sh
@@ -1,4 +1,3 @@
-readonly CONSTANT_TEAM_ID="<#teamId#>"
 readonly CONSTANT_API_KEY_ID="<#API_KEY_ID#>"
 readonly CONSTANT_ISSUER_ID="<#ISSUER_ID#>"
 readonly CONSTANT_MATCH_REPO="git@github.com:{organization}\/{repo}.git"
@@ -6,7 +5,6 @@ readonly CONSTANT_MATCH_REPO="git@github.com:{organization}\/{repo}.git"
 readonly WORKING_DIR=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 MATCH_REPO_ESCAPED=$(echo "${MATCH_REPO//\//\\\/}")
 
-LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_TEAM_ID/4TWS7E2EPE/g" {} +
 LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_API_KEY_ID/$API_KEY_ID/g" {} +
 LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_ISSUER_ID/$ISSUER_ID/g" {} +
 LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_MATCH_REPO/$MATCH_REPO_ESCAPED/g" {} +


### PR DESCRIPTION
- Close #https://github.com/nimblehq/ios-templates/issues/330

## What happened 👀

When generating a new project from make.sh, the Signing is automatic signing. This does not change when running fastlane match.

This causes issues:

CICD fail if the user did not modify Signing manually.
CICD fail if the user modify Signing manually but push incorrect settings.
Local build fail the user did not modify Signing manually.

## Insights

Added `updateCodeSigningSettings` to update the xcode project with synced match provisioning profiles after each match sync

Added syncDevelopmentProductionCodeSigningLane since there was no lane to generate a provisioning profile for Debug Production configuration.

## Proof Of Work 📹

<img width="1062" alt="Screenshot 2566-03-01 at 11 45 06" src="https://user-images.githubusercontent.com/9453323/222047032-78b7acc6-8e33-4eb7-b8a5-4a3bfc19d4f8.png">

<img width="798" alt="Screenshot 2566-03-01 at 11 23 47" src="https://user-images.githubusercontent.com/9453323/222047068-0ebc60ef-6d54-4d31-ba2b-9e3f5631f4e9.png">


