### PR TITLE
[#316] Use build number from CI/CD

### DIFF
--- a/.github/wiki/Bitrise.md
+++ b/.github/wiki/Bitrise.md
@@ -34,6 +34,10 @@ Out of the box, the Bitrise Template has the following workflows and steps:
 - MATCH_REPO_URL
 > Link to a repository that contains your Fastlane Match it can be either HTTPS or SSH link (e.g., https://github.com/nimblehq/fastlane-match.git)
 
+- BUILD NUMBER OFFSET
+
+> Set this variable value in the **Set Xcode Project Build Number** step in Bitrise in case you switch to Bitrise from another CI/CD and want to keep the build number of the application. 
+
 ### Workflow Environment Variables
 All four workflows have their own variables:
 
@@ -52,14 +56,14 @@ All four workflows have their own variables:
 
 ## Installation
 1. Follow the setup instruction in [`README.md`](https://github.com/nimblehq/ios-templates#readme).
-2. To connect your repository to Bitrise please follow the instruction in this page: [Adding a new app](https://devcenter.bitrise.io/en/getting-started/adding-your-first-app.html).
-3. Make sure the option where the `bitrise.yml` locate is set to `Store in-app repository`.
+2. To connect your repository to Bitrise, please follow the instruction on this page: [Adding a new app](https://devcenter.bitrise.io/en/getting-started/adding-your-first-app.html).
+3. Ensure the option where the `bitrise.yml` is located is set to `Store in-app repository`.
 <p align="center">
   <img src="assets/images/operations/bitrise/Bitrise-YML-Storage-Location.png" alt="Bitrise Store in-app repository" width="600"/>
 </p>
 
 4. Provide all the required variables and secrets.
-> Final project directory structure
+> The final project directory structure
 ```
 ROOT
 ├── ExampleApp.xcworkspace

--- a/.github/workflows/deploy_app_store.yml
+++ b/.github/workflows/deploy_app_store.yml
@@ -72,6 +72,10 @@ jobs:
       run: bundle exec pod install
       shell: bash
 
+    - uses: yanamura/ios-bump-version@v1
+      with:
+        build-number: ${{github.run_number}}
+
     - name: Build and Test
       run: bundle exec fastlane buildAndTest
 

--- a/.github/workflows/deploy_app_store.yml
+++ b/.github/workflows/deploy_app_store.yml
@@ -74,7 +74,7 @@ jobs:
 
     - uses: yanamura/ios-bump-version@v1
       with:
-        build-number: ${{github.run_number}}
+        build-number: ${{ github.run_number }}
 
     - name: Build and Test
       run: bundle exec fastlane buildAndTest

--- a/.github/workflows/deploy_app_store.yml
+++ b/.github/workflows/deploy_app_store.yml
@@ -74,7 +74,7 @@ jobs:
 
     - uses: yanamura/ios-bump-version@v1
       with:
-        build-number: ${{ github.run_number }}
+        build-number: ${{github.run_number}}
 
     - name: Build and Test
       run: bundle exec fastlane buildAndTest

--- a/.github/workflows/deploy_production_firebase.yml
+++ b/.github/workflows/deploy_production_firebase.yml
@@ -71,7 +71,7 @@ jobs:
 
     - uses: yanamura/ios-bump-version@v1
       with:
-        build-number: ${{github.run_number}}
+        build-number: ${{ github.run_number }}
 
     - name: Build and Test
       run: bundle exec fastlane buildAndTest

--- a/.github/workflows/deploy_production_firebase.yml
+++ b/.github/workflows/deploy_production_firebase.yml
@@ -71,7 +71,7 @@ jobs:
 
     - uses: yanamura/ios-bump-version@v1
       with:
-        build-number: ${{ github.run_number }}
+        build-number: ${{github.run_number}}
 
     - name: Build and Test
       run: bundle exec fastlane buildAndTest

--- a/.github/workflows/deploy_production_firebase.yml
+++ b/.github/workflows/deploy_production_firebase.yml
@@ -69,6 +69,10 @@ jobs:
       run: bundle exec pod install
       shell: bash
 
+    - uses: yanamura/ios-bump-version@v1
+      with:
+        build-number: ${{github.run_number}}
+
     - name: Build and Test
       run: bundle exec fastlane buildAndTest
 

--- a/.github/workflows/deploy_staging_firebase.yml
+++ b/.github/workflows/deploy_staging_firebase.yml
@@ -77,7 +77,7 @@ jobs:
 
     - uses: yanamura/ios-bump-version@v1
       with:
-        build-number: ${{ github.run_number }}
+        build-number: ${{github.run_number}}
 
     - name: Build and Test
       run: bundle exec fastlane buildAndTest

--- a/.github/workflows/deploy_staging_firebase.yml
+++ b/.github/workflows/deploy_staging_firebase.yml
@@ -77,7 +77,7 @@ jobs:
 
     - uses: yanamura/ios-bump-version@v1
       with:
-        build-number: ${{github.run_number}}
+        build-number: ${{ github.run_number }}
 
     - name: Build and Test
       run: bundle exec fastlane buildAndTest

--- a/.github/workflows/deploy_staging_firebase.yml
+++ b/.github/workflows/deploy_staging_firebase.yml
@@ -75,6 +75,10 @@ jobs:
       run: bundle exec pod install
       shell: bash
 
+    - uses: yanamura/ios-bump-version@v1
+      with:
+        build-number: ${{github.run_number}}
+
     - name: Build and Test
       run: bundle exec fastlane buildAndTest
 

--- a/.github/workflows/test_upload_build_to_test_flight.yml
+++ b/.github/workflows/test_upload_build_to_test_flight.yml
@@ -62,6 +62,10 @@ jobs:
       env:
         MATCH_PASSWORD: ${{ secrets.MATCH_PASS }}
 
+    - uses: yanamura/ios-bump-version@v1
+      with:
+        build-number: ${{github.run_number}}
+
     - name: Build App and Distribute to AppStore
       run: bundle exec fastlane buildAndUploadToAppStore
       env:

--- a/.github/workflows/test_upload_build_to_test_flight.yml
+++ b/.github/workflows/test_upload_build_to_test_flight.yml
@@ -64,7 +64,7 @@ jobs:
 
     - uses: yanamura/ios-bump-version@v1
       with:
-        build-number: ${{ github.run_number }}
+        build-number: ${{github.run_number}}
 
     - name: Build App and Distribute to AppStore
       run: bundle exec fastlane buildAndUploadToAppStore

--- a/.github/workflows/test_upload_build_to_test_flight.yml
+++ b/.github/workflows/test_upload_build_to_test_flight.yml
@@ -64,7 +64,7 @@ jobs:
 
     - uses: yanamura/ios-bump-version@v1
       with:
-        build-number: ${{github.run_number}}
+        build-number: ${{ github.run_number }}
 
     - name: Build App and Distribute to AppStore
       run: bundle exec fastlane buildAndUploadToAppStore

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -30,6 +30,9 @@ workflows:
     - git-clone@6.1: {}
     - cache-pull@2: {}
     - cocoapods-install@2: {}
+    - set-xcode-build-number@1:
+        inputs:
+        - plist_path: Project/$BITRISE_SCHEME/Configurations/Plists/Info.plist
     - xcode-test@4.0: {}
     - fastlane-match@0:
         inputs:
@@ -75,6 +78,9 @@ workflows:
     - git-clone@6.1: {}
     - cache-pull@2: {}
     - cocoapods-install@2: {}
+    - set-xcode-build-number@1:
+        inputs:
+        - plist_path: Project/$BITRISE_SCHEME/Configurations/Plists/Info.plist
     - xcode-test@4.0: {}
     - fastlane-match@0:
         inputs:
@@ -120,6 +126,9 @@ workflows:
     - git-clone@6.1: {}
     - cache-pull@2: {}
     - cocoapods-install@2: {}
+    - set-xcode-build-number@1:
+        inputs:
+        - plist_path: Project/$BITRISE_SCHEME/Configurations/Plists/Info.plist
     - xcode-test@4.0: {}
     - fastlane-match@0:
         inputs:

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -22,6 +22,13 @@ workflows:
           script: bundle install --path vendor/bundle
         - name: Install Pods Dependencies
           script: bundle exec pod install
+        - name: Set the build version
+          script: |
+            #!/bin/sh
+            set -e
+            set -x
+            cd $CM_BUILD_DIR
+            agvtool new-version -all $(($BUILD_NUMBER + 1))
         - name: Build and Test
           script: bundle exec fastlane buildAndTest
         - name: Match Ad-hoc
@@ -54,6 +61,13 @@ workflows:
           script: bundle install --path vendor/bundle
         - name: Install Pods Dependencies
           script: bundle exec pod install
+        - name: Set the build version
+          script: |
+            #!/bin/sh
+            set -e
+            set -x
+            cd $CM_BUILD_DIR
+            agvtool new-version -all $(($BUILD_NUMBER + 1))
         - name: Build and Test
           script: bundle exec fastlane buildAndTest
         - name: Match Ad-hoc
@@ -86,6 +100,13 @@ workflows:
           script: bundle install --path vendor/bundle
         - name: Install Pods Dependencies
           script: bundle exec pod install
+        - name: Set the build version
+          script: |
+            #!/bin/sh
+            set -e
+            set -x
+            cd $CM_BUILD_DIR
+            agvtool new-version -all $(($BUILD_NUMBER + 1))
         - name: Build and Test
           script: bundle exec fastlane buildAndTest
         - name: Match AppStore

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -111,12 +111,6 @@ class Fastfile: LaneFile {
 
         setAppVersion()
         AppStoreAuthentication.connectAPIKey()
-//        if Secret.bumpAppStoreBuildNumber {
-//            bumpAppstoreBuild()
-//        } else {
-//            bumpBuild()
-//        }
-
         buildAppStoreLane()
 
         Distribution.uploadToAppStore()

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -80,7 +80,6 @@ class Fastfile: LaneFile {
         desc("Build Staging app and upload to Firebase")
 
         setAppVersion()
-//        bumpBuild()
 
         buildAdHocStagingLane()
 
@@ -96,7 +95,6 @@ class Fastfile: LaneFile {
         desc("Build Production app and upload to Firebase")
 
         setAppVersion()
-//        bumpBuild()
 
         buildAdHocProductionLane()
 
@@ -132,7 +130,6 @@ class Fastfile: LaneFile {
         desc("Build Production app and upload to TestFlight")
 
         setAppVersion()
-//        bumpBuild()
 
         buildAppStoreLane()
 
@@ -195,22 +192,4 @@ class Fastfile: LaneFile {
             versionNumber: .userDefined(Constant.manualVersion)
         )
     }
-
-//    private func bumpBuild(buildNumber: Int = numberOfCommits()) {
-//        desc("Set build number with number of commits")
-//        incrementBuildNumber(
-//            buildNumber: .userDefined(String(buildNumber)),
-//            xcodeproj: .userDefined(Constant.projectPath)
-//        )
-//    }
-//
-//    private func bumpAppstoreBuild() {
-//        desc("Set build number with App Store latest build")
-//        let theLatestBuildNumber = latestTestflightBuildNumber(
-//            appIdentifier: Constant.productionBundleId
-//        ) + 1
-//        incrementBuildNumber(
-//            buildNumber: .userDefined("\(theLatestBuildNumber)")
-//        )
-//    }
 }

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -80,7 +80,7 @@ class Fastfile: LaneFile {
         desc("Build Staging app and upload to Firebase")
 
         setAppVersion()
-        bumpBuild()
+//        bumpBuild()
 
         buildAdHocStagingLane()
 
@@ -96,7 +96,7 @@ class Fastfile: LaneFile {
         desc("Build Production app and upload to Firebase")
 
         setAppVersion()
-        bumpBuild()
+//        bumpBuild()
 
         buildAdHocProductionLane()
 
@@ -113,11 +113,11 @@ class Fastfile: LaneFile {
 
         setAppVersion()
         AppStoreAuthentication.connectAPIKey()
-        if Secret.bumpAppStoreBuildNumber {
-            bumpAppstoreBuild()
-        } else {
-            bumpBuild()
-        }
+//        if Secret.bumpAppStoreBuildNumber {
+//            bumpAppstoreBuild()
+//        } else {
+//            bumpBuild()
+//        }
 
         buildAppStoreLane()
 
@@ -132,7 +132,7 @@ class Fastfile: LaneFile {
         desc("Build Production app and upload to TestFlight")
 
         setAppVersion()
-        bumpBuild()
+//        bumpBuild()
 
         buildAppStoreLane()
 
@@ -196,21 +196,21 @@ class Fastfile: LaneFile {
         )
     }
 
-    private func bumpBuild(buildNumber: Int = numberOfCommits()) {
-        desc("Set build number with number of commits")
-        incrementBuildNumber(
-            buildNumber: .userDefined(String(buildNumber)),
-            xcodeproj: .userDefined(Constant.projectPath)
-        )
-    }
-
-    private func bumpAppstoreBuild() {
-        desc("Set build number with App Store latest build")
-        let theLatestBuildNumber = latestTestflightBuildNumber(
-            appIdentifier: Constant.productionBundleId
-        ) + 1
-        incrementBuildNumber(
-            buildNumber: .userDefined("\(theLatestBuildNumber)")
-        )
-    }
+//    private func bumpBuild(buildNumber: Int = numberOfCommits()) {
+//        desc("Set build number with number of commits")
+//        incrementBuildNumber(
+//            buildNumber: .userDefined(String(buildNumber)),
+//            xcodeproj: .userDefined(Constant.projectPath)
+//        )
+//    }
+//
+//    private func bumpAppstoreBuild() {
+//        desc("Set build number with App Store latest build")
+//        let theLatestBuildNumber = latestTestflightBuildNumber(
+//            appIdentifier: Constant.productionBundleId
+//        ) + 1
+//        incrementBuildNumber(
+//            buildNumber: .userDefined("\(theLatestBuildNumber)")
+//        )
+//    }
 }


### PR DESCRIPTION
- Close #316 

## What happened 👀

CI/CD tools like Bitrise, GitHubAction, and Codemagic provide the build number so we can use that for the build number of the application. We will update our templates for Bitrise and GitHubAction to get the following benefit:

It is easier to track the commit of a version.
Make the build number more predictable.
Avoid duplicate build numbers when rebuilding the same commit (after registering a new device, we must re-deploy the app).
CI machines don't have to clone the whole project history to get the correct number of commits, reducing the overall build time and the cost of running CI/CD.


## Insight 📝

- added `ios-bump-version` step in github workflow
- added `set-xcode-build-number` step in bitrise

## Proof Of Work 📹

coming soon
