### PR TITLE
[#310] Support multiple apple portal accounts

### DIFF
--- a/fastlane/Constants/Constant.swift
+++ b/fastlane/Constants/Constant.swift
@@ -22,8 +22,10 @@ enum Constant {
 
     // MARK: - Match
 
-    static let userName = "<#userName#>"
-    static let teamId = "<#teamId#>"
+    static let appleStagingUserName = "<#userName#>"
+    static let appleStagingTeamId = "<#teamId#>"
+    static let appleProductionUserName = "<#userName#>"
+    static let appleProductionTeamId = "<#teamId#>"
     static let keychainName = "github_action_keychain"
     static let matchURL = "git@github.com:{organization}/{repo}.git"
 
@@ -116,6 +118,20 @@ extension Constant {
         var dsymPath: String {
             let outputDirectoryURL = URL(fileURLWithPath: Constant.outputPath)
             return outputDirectoryURL.appendingPathComponent(productName + ".app" + Constant.dSYMSuffix).relativePath
+        }
+        
+        var appleUsername: String {
+            switch self {
+            case .staging: return Constant.appleStagingUserName
+            case .production: return Constant.appleProductionUserName
+            }
+        }
+        
+        var appleTeamId: String {
+            switch self {
+            case .staging: return Constant.appleStagingTeamId
+            case .production: return Constant.appleProductionTeamId
+            }
         }
     }
 

--- a/fastlane/Constants/Constant.swift
+++ b/fastlane/Constants/Constant.swift
@@ -84,14 +84,14 @@ extension Constant {
         case production = "Production"
 
         var productName: String { "\(Constant.projectName) \(rawValue)".trimmed }
-        
+
         var scheme: String {
             switch self {
             case .staging: return "\(Constant.projectName) \(rawValue)".trimmed
             case .production: return Constant.projectName.trimmed
             }
         }
-        
+
         var bundleId: String {
             switch self {
             case .staging: return Constant.stagingBundleId

--- a/fastlane/Constants/Constant.swift
+++ b/fastlane/Constants/Constant.swift
@@ -84,14 +84,14 @@ extension Constant {
         case production = "Production"
 
         var productName: String { "\(Constant.projectName) \(rawValue)".trimmed }
-
+        
         var scheme: String {
             switch self {
             case .staging: return "\(Constant.projectName) \(rawValue)".trimmed
-            case .production: return Constant.projectName
+            case .production: return Constant.projectName.trimmed
             }
         }
-
+        
         var bundleId: String {
             switch self {
             case .staging: return Constant.stagingBundleId

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -107,7 +107,6 @@ class Fastfile: LaneFile {
         desc("Build Production app and upload to App Store")
 
         setAppVersion()
-        AppStoreAuthentication.connectAPIKey()
         if Secret.bumpAppStoreBuildNumber {
             bumpAppstoreBuild()
         } else {
@@ -116,6 +115,7 @@ class Fastfile: LaneFile {
 
         buildAppStoreLane()
 
+        AppStoreAuthentication.connectAPIKey()
         Distribution.uploadToAppStore()
 
         Symbol.uploadToCrashlytics(environment: .production)

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -107,7 +107,7 @@ class Fastfile: LaneFile {
         desc("Build Production app and upload to App Store")
 
         setAppVersion()
-        AppStoreAuthentication.connectAPIKey()
+        AppStoreAuthentication.connectProductionAPIKey()
         if Secret.bumpAppStoreBuildNumber {
             bumpAppstoreBuild()
         } else {
@@ -131,7 +131,7 @@ class Fastfile: LaneFile {
 
         buildAppStoreLane()
 
-        AppStoreAuthentication.connectAPIKey()
+        AppStoreAuthentication.connectProductionAPIKey()
         Distribution.uploadToTestFlight()
 
         Symbol.uploadToCrashlytics(environment: .production)
@@ -167,7 +167,7 @@ class Fastfile: LaneFile {
         registerDevice(
             name: deviceName,
             udid: deviceUDID,
-            teamId: .userDefined(Constant.teamId)
+            teamId: .userDefined(Constant.appleStagingTeamId)
         )
 
         Match.syncCodeSigning(type: .development, environment: .staging, isForce: true)

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -107,6 +107,7 @@ class Fastfile: LaneFile {
         desc("Build Production app and upload to App Store")
 
         setAppVersion()
+        AppStoreAuthentication.connectAPIKey()
         if Secret.bumpAppStoreBuildNumber {
             bumpAppstoreBuild()
         } else {
@@ -115,7 +116,6 @@ class Fastfile: LaneFile {
 
         buildAppStoreLane()
 
-        AppStoreAuthentication.connectAPIKey()
         Distribution.uploadToAppStore()
 
         Symbol.uploadToCrashlytics(environment: .production)

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -107,7 +107,7 @@ class Fastfile: LaneFile {
         desc("Build Production app and upload to App Store")
 
         setAppVersion()
-        AppStoreAuthentication.connectProductionAPIKey()
+        AppStoreAuthentication.connectAPIKey()
         if Secret.bumpAppStoreBuildNumber {
             bumpAppstoreBuild()
         } else {
@@ -131,7 +131,7 @@ class Fastfile: LaneFile {
 
         buildAppStoreLane()
 
-        AppStoreAuthentication.connectProductionAPIKey()
+        AppStoreAuthentication.connectAPIKey()
         Distribution.uploadToTestFlight()
 
         Symbol.uploadToCrashlytics(environment: .production)

--- a/fastlane/Helpers/AppStoreAuthentication.swift
+++ b/fastlane/Helpers/AppStoreAuthentication.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum AppStoreAuthentication {
 
-    static func connectProductionAPIKey() {
+    static func connectAPIKey() {
         appStoreConnectApiKey(
             keyId: Secret.appStoreKeyIdKey,
             issuerId: Secret.appStoreIssuerIdKey,

--- a/fastlane/Helpers/AppStoreAuthentication.swift
+++ b/fastlane/Helpers/AppStoreAuthentication.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum AppStoreAuthentication {
 
-    static func connectAPIKey() {
+    static func connectProductionAPIKey() {
         appStoreConnectApiKey(
             keyId: Secret.appStoreKeyIdKey,
             issuerId: Secret.appStoreIssuerIdKey,

--- a/fastlane/Helpers/Match.swift
+++ b/fastlane/Helpers/Match.swift
@@ -15,8 +15,8 @@ enum Match {
                 type: type.match,
                 readonly: .userDefined(!isForce),
                 appIdentifier: [environment.bundleId],
-                username: .userDefined(Constant.userName),
-                teamId: .userDefined(Constant.teamId),
+                username: .userDefined(environment.appleUsername),
+                teamId: .userDefined(environment.appleTeamId),
                 gitUrl: Constant.matchURL,
                 keychainName: Constant.keychainName,
                 keychainPassword: .userDefined(Secret.keychainPassword),
@@ -27,8 +27,8 @@ enum Match {
                 type: type.match,
                 readonly: .userDefined(!isForce),
                 appIdentifier: [environment.bundleId],
-                username: .userDefined(Constant.userName),
-                teamId: .userDefined(Constant.teamId),
+                username: .userDefined(environment.appleUsername),
+                teamId: .userDefined(environment.appleTeamId),
                 gitUrl: Constant.matchURL,
                 force: .userDefined(isForce)
             )
@@ -41,7 +41,7 @@ enum Match {
         updateCodeSigningSettings(
             path: Constant.projectPath,
             useAutomaticSigning: .userDefined(false),
-            teamId: .userDefined(Constant.teamId),
+            teamId: .userDefined(environment.appleTeamId),
             targets: .userDefined([Constant.projectName]),
             buildConfigurations: .userDefined([Self.createBuildConfiguration(type: type, environment: environment)]),
             codeSignIdentity: .userDefined(type.codeSignIdentity),


### PR DESCRIPTION
- Close #https://github.com/nimblehq/ios-templates/issues/310

## What happened 👀

Added separate username and team ids for staging and production

## Insight 📝

Didnt change appStoreConnectApiKey since it is very unlikely we need to upload both staging and production to appstore if they are using different apple accounts. 

Removed duplicated Environment enum from Match.swift

