### PR TITLE
[#460] [Chore] Replace cancel-workflow-action to Github Action's concurrency

### DIFF
--- a/.github/workflows/automatic_pull_request_review.yml
+++ b/.github/workflows/automatic_pull_request_review.yml
@@ -4,16 +4,15 @@ on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   review_pull_request:
     name: Pull request review by Danger
     runs-on: macOS-12
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.5.0
-      with:
-        access_token: ${{ github.token }}
-
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0

--- a/.github/workflows/deploy_app_store.yml
+++ b/.github/workflows/deploy_app_store.yml
@@ -10,6 +10,10 @@ on:
     branches: [ master, main ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint
@@ -29,11 +33,6 @@ jobs:
     name: Build
     runs-on: macOS-latest
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.5.0
-      with:
-        access_token: ${{ github.token }}
-
     - name: Checkout Repo
       uses: actions/checkout@v2
     # Set fetch-depth (default: 1) to get whole tree

--- a/.github/workflows/deploy_production_firebase.yml
+++ b/.github/workflows/deploy_production_firebase.yml
@@ -10,6 +10,10 @@ on:
     branches: [ release/** ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Lint:
     name: lint
@@ -29,11 +33,6 @@ jobs:
     name: Build
     runs-on: macOS-latest
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.5.0
-      with:
-        access_token: ${{ github.token }}
-
     - uses: actions/checkout@v2
     # Set fetch-depth (default: 1) to get whole tree
       with:

--- a/.github/workflows/deploy_staging_firebase.yml
+++ b/.github/workflows/deploy_staging_firebase.yml
@@ -10,6 +10,10 @@ on:
     branches: [ develop ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint
@@ -29,11 +33,6 @@ jobs:
     name: Build
     runs-on: macOS-latest
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.5.0
-      with:
-        access_token: ${{ github.token }}
-
     - uses: actions/checkout@v2
     # Set fetch-depth (default: 1) to get whole tree
       with:

--- a/.github/workflows/test_install_script.yml
+++ b/.github/workflows/test_install_script.yml
@@ -4,16 +4,15 @@ on:
   push:
     branches: [ feature/**, bug/**, chore/** ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Test:
     name: Test
     runs-on: macOS-12
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.5.0
-      with:
-        access_token: ${{ github.token }}
-
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0

--- a/.github/workflows/test_upload_build_to_test_flight.yml
+++ b/.github/workflows/test_upload_build_to_test_flight.yml
@@ -11,16 +11,15 @@ name: Test Upload Build to TestFlight
 on:
   pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build
     runs-on: macOS-12
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.5.0
-      with:
-        access_token: ${{ github.token }}
-
     - name: Checkout Repo
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
- Close #460 

## What happened 👀

- Remove [Cancel Previous Runs Github Action ](https://github.com/styfle/cancel-workflow-action) in GitHub Workflows.
- Add Concurrency command to cancel previous Github Action run.

## Insight 📝

- We group the jobs by workflow name and pull request number or commit (branch pushed) to avoid canceling in-progress jobs from other workflows. 

## Proof Of Work 📹

![CleanShot 2023-03-30 at 16 25 06](https://user-images.githubusercontent.com/24598204/228792659-0d232fe1-d0a9-4060-8182-930b0d53fd93.png)



