### PR TITLE
[#498] [Chore] Update Workflows to use self-hosted runner

### DIFF
--- a/.github/workflows/automatic_pull_request_review.yml
+++ b/.github/workflows/automatic_pull_request_review.yml
@@ -11,8 +11,19 @@ concurrency:
 jobs:
   review_pull_request:
     name: Pull request review by Danger
-    runs-on: macOS-latest
+    runs-on: self-hosted
     steps:
+    - name: Determine Runner Port
+      id: runner_port
+      run: |
+        last_char=$(echo "${{ runner.name }}" | tail -c 2 | head -c 1)
+        if [ "$last_char" = "1" ]; then
+          echo "runner_port=2000" >> $GITHUB_ENV
+          echo "test_device=iPhone 14 Pro Max" >> $GITHUB_ENV
+        else
+          echo "runner_port=2001" >> $GITHUB_ENV
+          echo "test_device=iPhone SE (3rd generation)" >> $GITHUB_ENV
+        fi
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
@@ -51,12 +62,12 @@ jobs:
       run: bundle exec pod install
 
     - name: Build and Test
-      run: bundle exec fastlane buildAndTest
-      env:
-        CI: true
+      run: |
+        bundle exec fastlane buildAndTest --swift_server_port ${{ env.runner_port }}
 
     - name: Clean up previous code coverage report
-      run: bundle exec fastlane cleanUpOutput
+      run: |
+        bundle exec fastlane cleanUpOutput --swift_server_port ${{ env.runner_port }}
 
     - name: Review pull request by Danger
       env:

--- a/.github/workflows/deploy_app_store.yml
+++ b/.github/workflows/deploy_app_store.yml
@@ -33,8 +33,19 @@ jobs:
 
   build:
     name: Build
-    runs-on: macOS-latest
+    runs-on: self-hosted
     steps:
+    - name: Determine Runner Port and Test Device
+      id: runner_port_test_device
+      run: |
+        last_char=$(echo "${{ runner.name }}" | tail -c 2 | head -c 1)
+        if [ "$last_char" = "1" ]; then
+          echo "runner_port=2000" >> $GITHUB_ENV
+          echo "test_device=iPhone 14 Pro Max" >> $GITHUB_ENV
+        else
+          echo "runner_port=2001" >> $GITHUB_ENV
+          echo "test_device=iPhone SE (3rd generation)" >> $GITHUB_ENV
+        fi
     - name: Checkout Repo
       uses: actions/checkout@v3
     # Set fetch-depth (default: 1) to get whole tree
@@ -73,15 +84,18 @@ jobs:
       shell: bash
 
     - name: Build and Test
-      run: bundle exec fastlane buildAndTest
+      run: |
+        bundle exec fastlane buildAndTest --swift_server_port ${{ env.runner_port }}
 
     - name: Match AppStore
-      run: bundle exec fastlane syncAppStoreCodeSigning
+      run: |
+        bundle exec fastlane syncAppStoreCodeSigning --swift_server_port ${{ env.runner_port }}
       env:
         MATCH_PASSWORD: ${{ secrets.MATCH_PASS }}
 
     - name: Build App and Distribute to AppStore
-      run: bundle exec fastlane buildAndUploadToAppStore
+      run: |
+        bundle exec fastlane buildAndUploadToAppStore --swift_server_port ${{ env.runner_port }}
       env:
         APPSTORE_CONNECT_API_KEY: ${{ secrets.APPSTORE_CONNECT_API_KEY }}
         API_KEY_ID: ${{ secrets.API_KEY_ID }}

--- a/.github/workflows/deploy_production_firebase.yml
+++ b/.github/workflows/deploy_production_firebase.yml
@@ -31,9 +31,21 @@ jobs:
 
   build:
     name: Build
-    runs-on: macOS-latest
+    runs-on: self-hosted
     steps:
-    - uses: actions/checkout@v3
+    - name: Determine Runner Port
+      id: runner_port
+      run: |
+        last_char=$(echo "${{ runner.name }}" | tail -c 2 | head -c 1)
+        if [ "$last_char" = "1" ]; then
+          echo "runner_port=2000" >> $GITHUB_ENV
+          echo "test_device=iPhone 14 Pro Max" >> $GITHUB_ENV
+        else
+          echo "runner_port=2001" >> $GITHUB_ENV
+          echo "test_device=iPhone SE (3rd generation)" >> $GITHUB_ENV
+        fi
+    - name: Checkout Repo
+      uses: actions/checkout@v3
     # Set fetch-depth (default: 1) to get whole tree
       with:
         fetch-depth: 0
@@ -70,15 +82,18 @@ jobs:
       shell: bash
 
     - name: Build and Test
-      run: bundle exec fastlane buildAndTest
+      run: |
+        bundle exec fastlane buildAndTest --swift_server_port ${{ env.runner_port }}
 
     - name: Match Ad-hoc
-      run: bundle exec fastlane syncAdHocProductionCodeSigning
+      run: |
+        bundle exec fastlane syncAdHocProductionCodeSigning --swift_server_port ${{ env.runner_port }}
       env:
         MATCH_PASSWORD: ${{ secrets.MATCH_PASS }}
 
     - name: Build Production App and Distribute to Firebase
-      run: bundle exec fastlane buildProductionAndUploadToFirebase
+      run: |
+        bundle exec fastlane buildProductionAndUploadToFirebase --swift_server_port ${{ env.runner_port }}
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
 

--- a/.github/workflows/deploy_staging_firebase.yml
+++ b/.github/workflows/deploy_staging_firebase.yml
@@ -31,9 +31,21 @@ jobs:
 
   build:
     name: Build
-    runs-on: macOS-latest
+    runs-on: self-hosted
     steps:
-    - uses: actions/checkout@v3
+    - name: Determine Runner Port
+      id: runner_port
+      run: |
+        last_char=$(echo "${{ runner.name }}" | tail -c 2 | head -c 1)
+        if [ "$last_char" = "1" ]; then
+          echo "runner_port=2000" >> $GITHUB_ENV
+          echo "test_device=iPhone 14 Pro Max" >> $GITHUB_ENV
+        else
+          echo "runner_port=2001" >> $GITHUB_ENV
+          echo "test_device=iPhone SE (3rd generation)" >> $GITHUB_ENV
+        fi
+    - name: Checkout Repo
+      uses: actions/checkout@v3
     # Set fetch-depth (default: 1) to get whole tree
       with:
         fetch-depth: 0
@@ -76,15 +88,18 @@ jobs:
       shell: bash
 
     - name: Build and Test
-      run: bundle exec fastlane buildAndTest
+      run: |
+        bundle exec fastlane buildAndTest --swift_server_port ${{ env.runner_port }}
 
     - name: Match Ad-hoc
-      run: bundle exec fastlane syncAdHocStagingCodeSigning
+      run: |
+        bundle exec fastlane syncAdHocStagingCodeSigning --swift_server_port ${{ env.runner_port }}
       env:
         MATCH_PASSWORD: ${{ secrets.MATCH_PASS }}
 
     - name: Build App and Distribute to Firebase
-      run: bundle exec fastlane buildStagingAndUploadToFirebase
+      run: |
+        bundle exec fastlane buildStagingAndUploadToFirebase --swift_server_port ${{ env.runner_port }}
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
 

--- a/.github/workflows/test_swiftui_install_script.yml
+++ b/.github/workflows/test_swiftui_install_script.yml
@@ -11,9 +11,21 @@ concurrency:
 jobs:
   Test:
     name: Test
-    runs-on: macOS-12
+    runs-on: self-hosted
     steps:
-    - uses: actions/checkout@v3
+    - name: Determine Runner Port
+      id: runner_port
+      run: |
+        last_char=$(echo "${{ runner.name }}" | tail -c 2 | head -c 1)
+        if [ "$last_char" = "1" ]; then
+          echo "runner_port=2000" >> $GITHUB_ENV
+          echo "test_device=iPhone 14 Pro Max" >> $GITHUB_ENV
+        else
+          echo "runner_port=2001" >> $GITHUB_ENV
+          echo "test_device=iPhone SE (3rd generation)" >> $GITHUB_ENV
+        fi
+    - name: Checkout Repo
+      uses: actions/checkout@v3
 
     - name: Bundle install
       run: bundle install
@@ -22,6 +34,5 @@ jobs:
       run: sh make.sh --bundle-id co.nimblehq.template --bundle-id-staging co.nimblehq.template.staging --project-name TemplateApp --interface SwiftUI
 
     - name: Build and Test
-      run: bundle exec fastlane buildAndTest
-      env:
-        CI: true
+      run: |
+        bundle exec fastlane buildAndTest --swift_server_port ${{ env.runner_port }}

--- a/.github/workflows/test_uikit_install_script.yml
+++ b/.github/workflows/test_uikit_install_script.yml
@@ -11,9 +11,21 @@ concurrency:
 jobs:
   Test:
     name: Test
-    runs-on: macOS-latest
+    runs-on: self-hosted
     steps:
-    - uses: actions/checkout@v3
+    - name: Determine Runner Port
+      id: runner_port
+      run: |
+        last_char=$(echo "${{ runner.name }}" | tail -c 2 | head -c 1)
+        if [ "$last_char" = "1" ]; then
+          echo "runner_port=2000" >> $GITHUB_ENV
+          echo "test_device=iPhone 14 Pro Max" >> $GITHUB_ENV
+        else
+          echo "runner_port=2001" >> $GITHUB_ENV
+          echo "test_device=iPhone SE (3rd generation)" >> $GITHUB_ENV
+        fi
+    - name: Checkout Repo
+      uses: actions/checkout@v3
 
     - name: Bundle install
       run: bundle install
@@ -22,6 +34,5 @@ jobs:
       run: sh make.sh --bundle-id co.nimblehq.template --bundle-id-staging co.nimblehq.template.staging --project-name TemplateApp --interface UIKit
 
     - name: Build and Test
-      run: bundle exec fastlane buildAndTest
-      env:
-        CI: true
+      run: |
+        bundle exec fastlane buildAndTest --swift_server_port ${{ env.runner_port }}

--- a/.github/workflows/test_upload_build_to_firebase.yml
+++ b/.github/workflows/test_upload_build_to_firebase.yml
@@ -17,8 +17,19 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: macOS-latest
+    runs-on: self-hosted
     steps:
+    - name: Determine Runner Port
+      id: runner_port
+      run: |
+        last_char=$(echo "${{ runner.name }}" | tail -c 2 | head -c 1)
+        if [ "$last_char" = "1" ]; then
+          echo "runner_port=2000" >> $GITHUB_ENV
+          echo "test_device=iPhone 14 Pro Max" >> $GITHUB_ENV
+        else
+          echo "runner_port=2001" >> $GITHUB_ENV
+          echo "test_device=iPhone SE (3rd generation)" >> $GITHUB_ENV
+        fi
     - name: Checkout Repo
       uses: actions/checkout@v3
       with:
@@ -57,15 +68,18 @@ jobs:
         TEAM_ID: ${{ secrets.TEAM_ID }}
 
     - name: Set Up Test Project for Firebase
-      run: bundle exec fastlane setUpTestProject
+      run: |
+       bundle exec fastlane setUpTestProject --swift_server_port ${{ env.runner_port }}
 
     - name: Sync Ad Hoc Code Signing
-      run: bundle exec fastlane syncAdHocStagingCodeSigning
+      run: |
+       bundle exec fastlane syncAdHocStagingCodeSigning --swift_server_port ${{ env.runner_port }}
       env:
         MATCH_PASSWORD: ${{ secrets.MATCH_PASS }}
 
     - name: Build App and Distribute to Firebase
-      run: bundle exec fastlane buildStagingAndUploadToFirebase
+      run: |
+       bundle exec fastlane buildStagingAndUploadToFirebase --swift_server_port ${{ env.runner_port }}
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
 

--- a/.github/workflows/test_upload_build_to_test_flight.yml
+++ b/.github/workflows/test_upload_build_to_test_flight.yml
@@ -19,8 +19,19 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: macOS-latest
+    runs-on: self-hosted
     steps:
+    - name: Determine Runner Port
+      id: runner_port
+      run: |
+        last_char=$(echo "${{ runner.name }}" | tail -c 2 | head -c 1)
+        if [ "$last_char" = "1" ]; then
+          echo "runner_port=2000" >> $GITHUB_ENV
+          echo "test_device=iPhone 14 Pro Max" >> $GITHUB_ENV
+        else
+          echo "runner_port=2001" >> $GITHUB_ENV
+          echo "test_device=iPhone SE (3rd generation)" >> $GITHUB_ENV
+        fi
     - name: Checkout Repo
       uses: actions/checkout@v3
       with:
@@ -55,15 +66,18 @@ jobs:
         TEAM_ID: ${{ secrets.TEAM_ID }}
 
     - name: Set Up Test Project for App Store
-      run: bundle exec fastlane setUpTestProject
+      run: |
+       bundle exec fastlane setUpTestProject --swift_server_port ${{ env.runner_port }}
 
     - name: Sync App Store Code Signing
-      run: bundle exec fastlane syncAppStoreCodeSigning
+      run: |
+       bundle exec fastlane syncAppStoreCodeSigning --swift_server_port ${{ env.runner_port }}
       env:
         MATCH_PASSWORD: ${{ secrets.MATCH_PASS }}
 
     - name: Build App and Distribute to AppStore
-      run: bundle exec fastlane buildAndUploadToAppStore
+      run: |
+       bundle exec fastlane buildAndUploadToAppStore --swift_server_port ${{ env.runner_port }}
       env:
         APPSTORE_CONNECT_API_KEY: ${{ secrets.APPSTORE_CONNECT_API_KEY }}
         API_KEY_ID: ${{ secrets.API_KEY_ID }}

--- a/fastlane/Helpers/Match.swift
+++ b/fastlane/Helpers/Match.swift
@@ -9,30 +9,15 @@
 enum Match {
 
     static func syncCodeSigning(type: Constant.BuildType, environment: Constant.Environment, isForce: Bool = false) {
-        if isCi() {
-            Keychain.create()
-            match(
-                type: type.match,
-                readonly: .userDefined(!isForce),
-                appIdentifier: [environment.bundleId],
-                username: .userDefined(environment.appleUsername),
-                teamId: .userDefined(environment.appleTeamId),
-                gitUrl: Constant.matchURL,
-                keychainName: Constant.keychainName,
-                keychainPassword: .userDefined(Secret.keychainPassword),
-                force: .userDefined(isForce)
-            )
-        } else {
-            match(
-                type: type.match,
-                readonly: .userDefined(!isForce),
-                appIdentifier: [environment.bundleId],
-                username: .userDefined(environment.appleUsername),
-                teamId: .userDefined(environment.appleTeamId),
-                gitUrl: Constant.matchURL,
-                force: .userDefined(isForce)
-            )
-        }
+        match(
+            type: type.match,
+            readonly: .userDefined(!isForce),
+            appIdentifier: [environment.bundleId],
+            username: .userDefined(environment.appleUsername),
+            teamId: .userDefined(environment.appleTeamId),
+            gitUrl: Constant.matchURL,
+            force: .userDefined(isForce)
+        )
         updateCodeSigning(type: type, environment: environment)
     }
     


### PR DESCRIPTION
- Close #498 

## What happened 👀

The following changes has been made follow this [document](https://www.notion.so/nimblehq/Provision-Custom-MacOS-Runner-for-GitHub-Actions-ace7181d7bf24896804c7e3313c9c956?pvs=4): 

- Using the Self-Hosted Runner for workflows.
- Update Build, Sync Code Signing, and Distribute Steps in workflows.
- Update fastlane lane: syncCodeSigning and buildAndTest

## Insight 📝

- Test upload build to Firebase and test flight should be successful.
- Test SwiftUI and UIkit script should be successful.

## Proof Of Work 📹

![CleanShot 2023-07-20 at 10 25 20](https://github.com/nimblehq/ios-templates/assets/24598204/a955e9c2-97cd-4981-bb69-95534c1c9b02)

![CleanShot 2023-07-20 at 10 25 10](https://github.com/nimblehq/ios-templates/assets/24598204/2b247daf-ade1-457f-9972-ab6b8261bff4)


