### PR TITLE
[#494] Migrate make.sh to Swift command

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require './fastlane/Constants/Constants'
-
 # Warn when there is a big PR
 warn("This pull request is quite big (#{git.lines_of_code} lines changed), please consider splitting it into multiple pull requests.") if git.lines_of_code > 500
 

--- a/Scripts/Swift/Extensions/FileManager+Utils.swift
+++ b/Scripts/Swift/Extensions/FileManager+Utils.swift
@@ -85,7 +85,7 @@ extension FileManager {
         if let enumerator = enumerator(
             at: url, 
             includingPropertiesForKeys: [.isRegularFileKey], 
-            options: [.skipsHiddenFiles, .skipsPackageDescendants]
+            options: [.skipsPackageDescendants]
         ) {
             for case let fileURL as URL in enumerator {
                 let fileAttributes = try? fileURL.resourceValues(forKeys:[.isRegularFileKey])

--- a/Scripts/Swift/Extensions/FileManager+Utils.swift
+++ b/Scripts/Swift/Extensions/FileManager+Utils.swift
@@ -34,6 +34,28 @@ extension FileManager {
         }
     }
 
+    func copy(file: String, to destination: String) {
+        let currentDirectory = currentDirectoryPath
+        do {
+            try copyItem(
+                atPath: "\(currentDirectory)/\(file)",
+                toPath:"\(currentDirectory)/\(destination)"
+            )
+        } catch {
+            print("Error \(error)")
+        }
+    }
+
+    func createFile(name: String, at directory: String) {
+        let currentDirectory = currentDirectoryPath
+        do {
+            try createDirectory(atPath: "\(currentDirectory)/\(directory)", withIntermediateDirectories: true, attributes: nil)
+        } catch {
+            print("Error \(error)")
+        }
+        createFile(atPath: "\(currentDirectory)\(directory)\(name)", contents: nil)
+    }
+
     func removeItems(in directory: String) {
         let currentDirectory = currentDirectoryPath
         do {

--- a/Scripts/Swift/Extensions/FileManager+Utils.swift
+++ b/Scripts/Swift/Extensions/FileManager+Utils.swift
@@ -88,6 +88,7 @@ extension FileManager {
             options: [.skipsPackageDescendants]
         ) {
             for case let fileURL as URL in enumerator {
+                guard fileURL.absoluteString ~= "([^\\/]+\\..*)" else { continue }
                 let fileAttributes = try? fileURL.resourceValues(forKeys:[.isRegularFileKey])
                 guard fileAttributes?.isRegularFile ?? false else { continue }
                 files.append(fileURL)

--- a/Scripts/Swift/Extensions/FileManager+Utils.swift
+++ b/Scripts/Swift/Extensions/FileManager+Utils.swift
@@ -87,8 +87,9 @@ extension FileManager {
             includingPropertiesForKeys: [.isRegularFileKey], 
             options: [.skipsPackageDescendants]
         ) {
+            let hiddenFolderRegex = "\(directory.replacingOccurrences(of: "/", with: "\\/"))\\/\\..*\\/"
             for case let fileURL as URL in enumerator {
-                guard fileURL.absoluteString ~= "([^\\/]+\\..*)" else { continue }
+                guard !(fileURL.relativePath ~= hiddenFolderRegex) else { continue }
                 let fileAttributes = try? fileURL.resourceValues(forKeys:[.isRegularFileKey])
                 guard fileAttributes?.isRegularFile ?? false else { continue }
                 files.append(fileURL)

--- a/Scripts/Swift/Extensions/String+Utils.swift
+++ b/Scripts/Swift/Extensions/String+Utils.swift
@@ -1,0 +1,8 @@
+extension String {
+
+    static func ~= (lhs: String, rhs: String) -> Bool {
+        guard let regex = try? NSRegularExpression(pattern: rhs) else { return false }
+        let range = NSRange(location: 0, length: lhs.utf16.count)
+        return regex.firstMatch(in: lhs, options: [], range: range) != nil
+    }
+}

--- a/Scripts/Swift/SetUpCICDService.swift
+++ b/Scripts/Swift/SetUpCICDService.swift
@@ -1,50 +1,51 @@
-#!/usr/bin/swift
+struct SetUpCICDService {
 
-import Foundation
+    enum CICDService {
 
-let fileManager = FileManager.default
+        case github, bitrise, codemagic, later
 
-enum CICDService {
-    case github, bitrise, codemagic, later
-
-    init?(_ name: String) {
-        switch name.lowercased() {
-        case "g", "github":
-            self = .github
-        case "b", "bitrise":
-            self = .bitrise
-        case "c", "codemagic":
-            self = .codemagic
-        case "l", "later":
-            self = .later
-        default: 
-            return nil
+        init?(_ name: String) {
+            switch name.lowercased() {
+            case "g", "github":
+                self = .github
+            case "b", "bitrise":
+                self = .bitrise
+            case "c", "codemagic":
+                self = .codemagic
+            case "l", "later":
+                self = .later
+            default: 
+                return nil
+            }
         }
     }
+
+    private let fileManager = FileManager.default
+
+    func perform() {
+        var service: CICDService? = nil
+        while service == nil {
+            print("Which CI/CD service do you use (Can be edited later) [(g)ithub/(b)itrise/(c)odemagic/(l)ater]: ")
+            service = CICDService(readLine() ?? "")
+        }
+
+        switch service {
+        case .github:
+            print("Setting template for Github Actions")
+            fileManager.removeItems(in: "bitrise.yml")
+            fileManager.removeItems(in: "codemagic.yaml")
+        case .bitrise:
+            print("Setting template for Bitrise")
+            fileManager.removeItems(in: "codemagic.yaml")
+            fileManager.removeItems(in: ".github/workflows")
+        case .codemagic:
+            print("Setting template for CodeMagic")
+            fileManager.removeItems(in: "bitrise.yml")
+            fileManager.removeItems(in: ".github/workflows")
+        case .later, .none:
+            print("You can manually setup the template later.")
+        }
+
+        print("✅  Completed")
+    }
 }
-
-var service: CICDService? = nil
-
-while service == nil {
-    print("Which CI/CD service do you use (Can be edited later) [(g)ithub/(b)itrise/(c)odemagic/(l)ater]: ")
-    service = CICDService(readLine() ?? "")
-}
-
-switch service {
-case .github:
-    print("Setting template for Github Actions")
-    fileManager.removeItems(in: "bitrise.yml")
-    fileManager.removeItems(in: "codemagic.yaml")
-case .bitrise:
-    print("Setting template for Bitrise")
-    fileManager.removeItems(in: "codemagic.yaml")
-    fileManager.removeItems(in: ".github/workflows")
-case .codemagic:
-    print("Setting template for CodeMagic")
-    fileManager.removeItems(in: "bitrise.yml")
-    fileManager.removeItems(in: ".github/workflows")
-case .later, .none:
-    print("You can manually setup the template later.")
-}
-
-print("✅  Completed")

--- a/Scripts/Swift/SetUpDeliveryConstants.swift
+++ b/Scripts/Swift/SetUpDeliveryConstants.swift
@@ -1,18 +1,21 @@
-#!/usr/bin/swift
+struct SetUpDeliveryConstants {
 
-import Foundation
+    func perform() {
+        print("Do you want to set up Constants values? (Can be edited later) [Y/n]: ")
 
-let fileManager = FileManager.default
+        let arg = readLine() ?? "y"
 
-print("Do you want to set up Constants values? (Can be edited later) [Y/n]: ")
-
-var arg = readLine() ?? "y"
-
-switch arg.lowercased() {
-    case "y", "yes", "":
-        let error = try safeShell("open -a Xcode fastlane/Constants/Constant.swift")
-        guard let error = error, !error.isEmpty else { break }
-        print("Could not open Xcode. Make sure Xcode is installed and try again.\nRaw error: \(error)")
-    default:
-        print("✅  Completed. You can edit this file at 'fastlane/Constants/Constant.swift'.")
+        switch arg.lowercased() {
+            case "y", "yes":
+                do {
+                    let error = try safeShell("open -a Xcode fastlane/Constants/Constant.swift")
+                    guard let error = error, !error.isEmpty else { break }
+                    print("Could not open Xcode. Make sure Xcode is installed and try again.\nRaw error: \(error)")
+                } catch {
+                    print("Error: \(error)")
+                }
+            default:
+                print("✅  Completed. You can edit this file at 'fastlane/Constants/Constant.swift'.")
+        }
+    }
 }

--- a/Scripts/Swift/SetUpInterface.swift
+++ b/Scripts/Swift/SetUpInterface.swift
@@ -1,4 +1,3 @@
-
 struct SetUpInterface {
 
     enum Interface {
@@ -23,9 +22,9 @@ struct SetUpInterface {
         }
     }
 
-    func perform(_ interface: Interface, _ projectName: String) {
-        let fileManager = FileManager.default
+    let fileManager = FileManager.default
 
+    func perform(_ interface: Interface, _ projectName: String) {
         switch interface {
         case .swiftUI:
             print("=> 🦅 Setting up SwiftUI")

--- a/Scripts/Swift/SetUpInterface.swift
+++ b/Scripts/Swift/SetUpInterface.swift
@@ -22,7 +22,7 @@ struct SetUpInterface {
         }
     }
 
-    let fileManager = FileManager.default
+    private let fileManager = FileManager.default
 
     func perform(_ interface: Interface, _ projectName: String) {
         switch interface {

--- a/Scripts/Swift/SetUpInterface.swift
+++ b/Scripts/Swift/SetUpInterface.swift
@@ -1,25 +1,47 @@
-#!/usr/bin/swift
 
-import Foundation
+struct SetUpInterface {
 
-let fileManager = FileManager.default
+    enum Interface {
 
-var interface = "UIKit"
+        case swiftUI, uiKit
 
-switch CommandLine.arguments[1] {
-case "SwiftUI", "s", "S":
-    print("=> 🦅 Setting up SwiftUI")
-    interface = "SwiftUI"
-    let swiftUIAppDirectory = "tuist/Interfaces/SwiftUI/Sources/Application"
-    fileManager.rename(
-        file: "\(swiftUIAppDirectory)/App.swift",
-        to: "\(swiftUIAppDirectory)/\(CommandLine.arguments[2])App.swift"
-    )
-default:
-    print("=> 🦉 Setting up UIKit")
-    interface = "UIKit"
+        init?(_ name: String) {
+            switch name.lowercased() {
+            case "s", "swiftui":
+                self = .swiftUI
+            case "u", "uikit":
+                self = .uiKit
+            default: return nil
+            }
+        }
+
+        var folderName: String {
+            switch self {
+                case .swiftUI: return "SwiftUI"
+                case .uiKit: return "UIKit"
+            }
+        }
+    }
+
+    func perform(_ interface: Interface, _ projectName: String) {
+        let fileManager = FileManager.default
+
+        switch interface {
+        case .swiftUI:
+            print("=> 🦅 Setting up SwiftUI")
+            let swiftUIAppDirectory = "tuist/Interfaces/SwiftUI/Sources/Application"
+            fileManager.rename(
+                file: "\(swiftUIAppDirectory)/App.swift",
+                to: "\(swiftUIAppDirectory)/\(projectName)App.swift"
+            )
+        case .uiKit:
+            print("=> 🦉 Setting up UIKit")
+        }
+
+        let folderName = interface.folderName
+
+        fileManager.moveFiles(in: "tuist/Interfaces/\(folderName)/Project", to: "")
+        fileManager.moveFiles(in: "tuist/Interfaces/\(folderName)/Sources", to: "TemplateApp/Sources")
+        fileManager.removeItems(in: "tuist/Interfaces")
+    }
 }
-
-fileManager.moveFiles(in: "tuist/Interfaces/\(interface)/Project", to: "")
-fileManager.moveFiles(in: "tuist/Interfaces/\(interface)/Sources", to: "{PROJECT_NAME}/Sources")
-fileManager.removeItems(in: "tuist/Interfaces")

--- a/Scripts/Swift/SetUpiOSProject.swift
+++ b/Scripts/Swift/SetUpiOSProject.swift
@@ -1,181 +1,184 @@
 #!/usr/bin/swift
 
-let CONSTANT_PROJECT_NAME = "{PROJECT_NAME}"
-let CONSTANT_BUNDLE_PRODUCTION = "{BUNDLE_ID_PRODUCTION}"
-let CONSTANT_BUNDLE_STAGING = "{BUNDLE_ID_STAGING}"
-let CONSTANT_MINIMUM_VERSION = "{TARGET_VERSION}"
+class SetUpIOSProject {
 
-var bundleIdProduction = ""
-var bundleIdStaging = ""
-var projectName = ""
-var minimumVersion = ""
-var interface: SetUpInterface.Interface?
+    let CONSTANT_PROJECT_NAME = "{PROJECT_NAME}"
+    let CONSTANT_BUNDLE_PRODUCTION = "{BUNDLE_ID_PRODUCTION}"
+    let CONSTANT_BUNDLE_STAGING = "{BUNDLE_ID_STAGING}"
+    let CONSTANT_MINIMUM_VERSION = "{TARGET_VERSION}"
 
-var isCI = !(ProcessInfo.processInfo.environment["CI"] ?? "").isEmpty
+    private let fileManager = FileManager.default
 
-// TODO: Should be replaced with ArgumentParser instead of command line
-for (index, argument) in CommandLine.arguments.enumerated() {
-    switch index {
-    case 1: bundleIdProduction = argument
-    case 2: bundleIdStaging = argument
-    case 3: projectName = argument
-    case 4: minimumVersion = argument
-    case 5: interface = .init(argument)
-    default: break
+    var bundleIdProduction = ""
+    var bundleIdStaging = ""
+    var projectName = ""
+    var minimumVersion = ""
+    var interface: SetUpInterface.Interface?
+
+    var isCI = !(ProcessInfo.processInfo.environment["CI"] ?? "").isEmpty
+
+    func perform() throws {
+        // TODO: Should be replaced with ArgumentParser instead of command line
+        for (index, argument) in CommandLine.arguments.enumerated() {
+            switch index {
+            case 1: bundleIdProduction = argument
+            case 2: bundleIdStaging = argument
+            case 3: projectName = argument
+            case 4: minimumVersion = argument
+            case 5: interface = .init(argument)
+            default: break
+            }
+        }
+
+        if isCI {
+            minimumVersion = "14.0"
+        }
+
+        while bundleIdProduction.isEmpty || !checkPackageName(bundleIdProduction) {
+            print("BUNDLE ID PRODUCTION (i.e. com.example.project):")
+            bundleIdProduction = readLine() ?? ""
+        }
+        while bundleIdStaging.isEmpty || !checkPackageName(bundleIdStaging)  {
+            print("BUNDLE ID STAGING (i.e. com.example.project.staging):")
+            bundleIdStaging = readLine() ?? ""
+        }
+        while projectName.isEmpty {
+            print("PROJECT NAME (i.e. NewProject):")
+            projectName = readLine() ?? ""
+        }
+        while minimumVersion.isEmpty || !checkVersion(minimumVersion) {
+            print("iOS Minimum Version (i.e. 14.0):")
+            minimumVersion = readLine() ?? "14.0"
+        }
+        while interface == nil {
+            print("Interface [(S)wiftUI or (U)IKit]:")
+            interface = SetUpInterface.Interface(readLine() ?? "")
+        }
+        let projectNameNoSpace = projectName.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        print("=> 🐢 Starting init \(projectName) ...")
+
+        print("=> 🔎 Replacing files structure...")
+
+        // Rename test folder structure
+        fileManager.rename(file: "\(CONSTANT_PROJECT_NAME)Tests", to: "\(projectNameNoSpace)Tests")
+
+        // Rename KIF UI Test folder structure
+        fileManager.rename(file: "\(CONSTANT_PROJECT_NAME)KIFUITests", to: "\(projectNameNoSpace)KIFUITests")
+
+        // Rename app folder structure
+        fileManager.rename(file: "\(CONSTANT_PROJECT_NAME)", to: "\(projectNameNoSpace)")
+
+        // Duplicate the env example file to env file
+        fileManager.copy(file: ".env.example", to: ".env")
+
+        // Add AutoMockable.generated.swift file
+        fileManager.createFile(name: "AutoMockable.generated.swift", at: "\(projectNameNoSpace)Tests/Sources/Mocks/Sourcery")
+
+        // Add AutoMockable.generated.swift file
+        fileManager.createFile(name: "R.generated.swift", at: "\(projectNameNoSpace)/Sources/Supports/Helpers/Rswift")
+
+        // Select the Interface
+        SetUpInterface().perform(interface ?? .uiKit, projectName)
+
+        print("✅  Completed")
+
+        // Search and replace in files
+
+        print("=> 🔎 Replacing package and package name within files...")
+
+        try fileManager.replaceAllOccurrences(of: CONSTANT_BUNDLE_STAGING, to: bundleIdStaging)
+        try fileManager.replaceAllOccurrences(of: CONSTANT_BUNDLE_PRODUCTION, to: bundleIdProduction)
+        try fileManager.replaceAllOccurrences(of: CONSTANT_PROJECT_NAME, to: projectNameNoSpace)
+        try fileManager.replaceAllOccurrences(of: CONSTANT_MINIMUM_VERSION, to: minimumVersion)
+        print("✅  Completed")
+
+        // check for tuist and install
+        let tuistLocation = try safeShell("command -v tuist")
+        if let tuistLocation, tuistLocation.isEmpty {
+            print("Tuist could not be found")
+            print("Installing tuist")
+            try safeShell(
+                """
+                    readonly TUIST_VERSION=`cat .tuist-version`
+                    curl -Ls https://install.tuist.io | bash
+                    tuist install ${TUIST_VERSION}
+                """
+            )
+        }
+
+        // Generate with tuist
+        try safeShell("tuist generate --no-open")
+        print("✅  Completed")
+
+        // Install dependencies
+        print("Installing gems")
+        try safeShell("bundle install")
+
+        // Install dependencies
+        print("Run Arkana")
+        try safeShell("bundle exec arkana")
+
+        print("Installing pod dependencies")
+        try safeShell("bundle exec pod install --repo-update")
+        print("✅  Completed")
+
+        // Remove gitkeep files
+        print("Remove gitkeep files from project")
+        let escapedProjectNameNoSpace = projectNameNoSpace.replacingOccurrences(of: ".", with: "\\.")
+        try safeShell("sed -i \"\" \"s/.*\\(gitkeep\\).*,//\" \(escapedProjectNameNoSpace).xcodeproj/project.pbxproj")
+        print("✅  Complete")
+
+        // Remove Tuist files
+        print("Remove tuist files")
+        fileManager.removeItems(in: ".tuist-version")
+        fileManager.removeItems(in: "tuist")
+        fileManager.removeItems(in: "Project.swift")
+        fileManager.removeItems(in: "Workspace.swift")
+
+        // Remove script files and git/index
+        print("Remove script files and git/index")
+        fileManager.removeItems(in: "make.sh")
+        fileManager.removeItems(in: ".github/workflows/test_install_script.yml")
+        fileManager.removeItems(in: ".git/index")
+        try safeShell("git reset")
+
+        if !isCI {
+            SetUpCICDService().perform()
+            SetUpDeliveryConstants().perform()
+            fileManager.removeItems(in: "fastlane/Tests")
+            fileManager.removeItems(in: "set_up_test_testflight.sh")
+            fileManager.removeItems(in: "Scripts")
+        }
+
+        print("✅  Completed")
+
+        // Done!
+        print("=> 🚀 Done! App is ready to be tested 🙌")
+
+        if !isCI {
+            print("=> 🛠 Opening the project.")
+            try safeShell("open -a Xcode \(projectNameNoSpace).xcworkspace")
+        }
+    }
+
+    func checkPackageName(_ name: String) -> Bool {
+        let packageNameRegex="^[a-z][a-z0-9_]*(\\.[a-z0-9_-]+)+[0-9a-z_-]$"
+        let valid = name ~= packageNameRegex
+        if !valid {
+            print("Please pick a valid package name with pattern {com.example.package}")
+        }
+        return valid
+    }
+
+    func checkVersion(_ version: String) -> Bool {
+        let versionRegex="^[0-9_]+(\\.[0-9]+)+$"
+        let valid = version ~= versionRegex
+        if !valid {
+            print("Please pick a valid version with pattern {x.y}")
+        }
+        return valid
     }
 }
 
-if isCI {
-    minimumVersion = "14.0"
-}
-
-func checkPackageName(_ name: String) -> Bool {
-    let packageNameRegex="^[a-z][a-z0-9_]*(\\.[a-z0-9_-]+)+[0-9a-z_-]$"
-    let valid = name ~= packageNameRegex
-    if !valid {
-        print("Please pick a valid package name with pattern {com.example.package}")
-    }
-    return valid
-}
-
-func checkVersion(_ version: String) -> Bool {
-    let versionRegex="^[0-9_]+(\\.[0-9]+)+$"
-    let valid = version ~= versionRegex
-    if !valid {
-        print("Please pick a valid version with pattern {x.y}")
-    }
-    return valid
-}
-
-while bundleIdProduction.isEmpty || !checkPackageName(bundleIdProduction) {
-    print("BUNDLE ID PRODUCTION (i.e. com.example.project):")
-    bundleIdProduction = readLine() ?? ""
-}
-while bundleIdStaging.isEmpty || !checkPackageName(bundleIdStaging)  {
-    print("BUNDLE ID STAGING (i.e. com.example.project.staging):")
-    bundleIdStaging = readLine() ?? ""
-}
-while projectName.isEmpty {
-    print("PROJECT NAME (i.e. NewProject):")
-    projectName = readLine() ?? ""
-}
-while minimumVersion.isEmpty || !checkVersion(minimumVersion) {
-    print("iOS Minimum Version (i.e. 14.0):")
-    minimumVersion = readLine() ?? "14.0"
-}
-while interface == nil {
-    print("Interface [(S)wiftUI or (U)IKit]:")
-    interface = SetUpInterface.Interface(readLine() ?? "")
-}
-let projectNameNoSpace = projectName.trimmingCharacters(in: .whitespacesAndNewlines)
-
-print("=> 🐢 Starting init \(projectName) ...")
-
-print("=> 🔎 Replacing files structure...")
-
-let fileManager = FileManager.default
-
-// Rename test folder structure
-fileManager.rename(file: "\(CONSTANT_PROJECT_NAME)Tests", to: "\(projectNameNoSpace)Tests")
-
-// Rename KIF UI Test folder structure
-fileManager.rename(file: "\(CONSTANT_PROJECT_NAME)KIFUITests", to: "\(projectNameNoSpace)KIFUITests")
-
-// Rename app folder structure
-fileManager.rename(file: "\(CONSTANT_PROJECT_NAME)", to: "\(projectNameNoSpace)")
-
-// Duplicate the env example file to env file
-fileManager.copy(file: ".env.example", to: ".env")
-
-// Add AutoMockable.generated.swift file
-fileManager.createFile(name: "AutoMockable.generated.swift", at: "\(projectNameNoSpace)Tests/Sources/Mocks/Sourcery")
-
-// Add AutoMockable.generated.swift file
-fileManager.createFile(name: "R.generated.swift", at: "\(projectNameNoSpace)/Sources/Supports/Helpers/Rswift")
-
-// Select the Interface
-SetUpInterface().perform(interface ?? .uiKit, projectName)
-
-print("✅  Completed")
-
-// Search and replace in files
-
-print("=> 🔎 Replacing package and package name within files...")
-
-try fileManager.replaceAllOccurrences(of: CONSTANT_BUNDLE_STAGING, to: bundleIdStaging)
-try fileManager.replaceAllOccurrences(of: CONSTANT_BUNDLE_PRODUCTION, to: bundleIdProduction)
-try fileManager.replaceAllOccurrences(of: CONSTANT_PROJECT_NAME, to: projectNameNoSpace)
-try fileManager.replaceAllOccurrences(of: CONSTANT_MINIMUM_VERSION, to: minimumVersion)
-print("✅  Completed")
-
-// check for tuist and install
-let tuistLocation = try safeShell("command -v tuist")
-if let tuistLocation, tuistLocation.isEmpty {
-    print("Tuist could not be found")
-    print("Installing tuist")
-    try safeShell(
-        """
-            readonly TUIST_VERSION=`cat .tuist-version`
-            curl -Ls https://install.tuist.io | bash
-            tuist install ${TUIST_VERSION}
-        """
-    )
-}
-
-// Generate with tuist
-try safeShell("tuist generate --no-open")
-print("✅  Completed")
-
-// Install dependencies
-print("Installing gems")
-try safeShell("bundle install")
-
-// Install dependencies
-print("Run Arkana")
-try safeShell("bundle exec arkana")
-
-print("Installing pod dependencies")
-try safeShell("bundle exec pod install --repo-update")
-print("✅  Completed")
-
-// Remove gitkeep files
-print("Remove gitkeep files from project")
-let escapedProjectNameNoSpace = projectNameNoSpace.replacingOccurrences(of: ".", with: "\\.")
-try safeShell("sed -i \"\" \"s/.*\\(gitkeep\\).*,//\" \(escapedProjectNameNoSpace).xcodeproj/project.pbxproj")
-print("✅  Complete")
-
-// Remove Tuist files
-print("Remove tuist files")
-fileManager.removeItems(in: ".tuist-version")
-fileManager.removeItems(in: "tuist")
-fileManager.removeItems(in: "Project.swift")
-fileManager.removeItems(in: "Workspace.swift")
-
-// Remove script files and git/index
-print("Remove script files and git/index")
-fileManager.removeItems(in: "make.sh")
-fileManager.removeItems(in: ".github/workflows/test_install_script.yml")
-fileManager.removeItems(in: ".git/index")
-try safeShell("git reset")
-
-/*
-
-if [[ -z "${CI}" ]]; then
-    rm -rf fastlane/Tests
-    rm -f set_up_test_testflight.sh
-    cat Scripts/Swift/SetUpCICDService.swift Scripts/Swift/Extensions/FileManager+Utils.swift Scripts/Swift/Helpers/SafeShell.swift > t.swift && swift t.swift && rm -rf 't.swift'
-    cat Scripts/Swift/SetUpDeliveryConstants.swift Scripts/Swift/Extensions/FileManager+Utils.swift Scripts/Swift/Helpers/SafeShell.swift > t.swift && swift t.swift && rm -rf 't.swift'
-    rm -rf Scripts
-fi
-
-
-echo "✅  Completed"
-
-# Done!
-echo "=> 🚀 Done! App is ready to be tested 🙌"
-
-if [[ -z "${CI}" ]]; then
-    echo "=> 🛠 Opening the project."
-    open -a Xcode $PROJECT_NAME_NO_SPACES.xcworkspace
-fi
-*/
+try SetUpIOSProject().perform()

--- a/Scripts/Swift/SetUpiOSProject.swift
+++ b/Scripts/Swift/SetUpiOSProject.swift
@@ -87,7 +87,7 @@ class SetUpIOSProject {
         // Add AutoMockable.generated.swift file
         fileManager.createFile(name: "AutoMockable.generated.swift", at: "\(projectNameNoSpace)Tests/Sources/Mocks/Sourcery")
 
-        // Add AutoMockable.generated.swift file
+        // Add R.generated.swift file.
         fileManager.createFile(name: "R.generated.swift", at: "\(projectNameNoSpace)/Sources/Supports/Helpers/Rswift")
     }
 

--- a/make.sh
+++ b/make.sh
@@ -71,4 +71,4 @@ while [ $# -gt 0 ] ; do
     shift
 done
 
-cat Scripts/Swift/SetUpiOSProject.swift Scripts/Swift/SetUpInterface.swift Scripts/Swift/Extensions/FileManager+Utils.swift Scripts/Swift/Extensions/String+Utils.swift Scripts/Swift/Helpers/SafeShell.swift > t.swift && swift t.swift $bundle_id_production $bundle_id_staging $project_name "$minimum_version" $interface && rm -rf 't.swift'
+cat Scripts/Swift/SetUpiOSProject.swift Scripts/Swift/SetUpCICDService.swift Scripts/Swift/SetUpDeliveryConstants.swift Scripts/Swift/SetUpInterface.swift Scripts/Swift/Extensions/FileManager+Utils.swift Scripts/Swift/Extensions/String+Utils.swift Scripts/Swift/Helpers/SafeShell.swift > t.swift && swift t.swift $bundle_id_production $bundle_id_staging $project_name "$minimum_version" $interface && rm -rf 't.swift'

--- a/make.sh
+++ b/make.sh
@@ -35,10 +35,10 @@ project_name=""
 minimum_version=""
 interface=""
 
-readonly CONSTANT_PROJECT_NAME="TemplateApp"
-readonly CONSTANT_BUNDLE_PRODUCTION="co.nimblehq.ios.templates"
-readonly CONSTANT_BUNDLE_STAGING="co.nimblehq.ios.templates.staging"
-readonly CONSTANT_MINIMUM_VERSION=""
+readonly CONSTANT_PROJECT_NAME="{PROJECT_NAME}"
+readonly CONSTANT_BUNDLE_PRODUCTION="{BUNDLE_ID_PRODUCTION}"
+readonly CONSTANT_BUNDLE_STAGING="{BUNDLE_ID_STAGING}"
+readonly CONSTANT_MINIMUM_VERSION="{TARGET_VERSION}"
 
 while [ $# -gt 0 ] ; do
     case "$1" in
@@ -71,117 +71,4 @@ while [ $# -gt 0 ] ; do
     shift
 done
 
-cat Scripts/Swift/SetUpiOSProject.swift Scripts/Swift/SetUpInterface.swift Scripts/Swift/Extensions/FileManager+Utils.swift Scripts/Swift/Extensions/String+Utils.swift Scripts/Swift/Helpers/SafeShell.swift > t.swift && swift t.swift $bundle_id_production $bundle_id_staging $project_name $minimum_version $interface && rm -rf 't.swift'
-
-# Trim spaces in APP_NAME
-readonly PROJECT_NAME_NO_SPACES=$(echo "$project_name" | sed "s/ //g")
-
-# Rename files structure
-echo "=> 🔎 Replacing files structure..."
-
-
-## user define function
-rename_folder(){
-	local DIR=$1
-	local NEW_DIR=$2
-    if [ -d "$DIR" ]
-    then
-        mv ${DIR} ${NEW_DIR}
-    fi
-}
-
-# Rename test folder structure
-rename_folder "${CONSTANT_PROJECT_NAME}Tests" "${PROJECT_NAME_NO_SPACES}Tests"
-
-# Rename KIF UI Test folder structure
-rename_folder "${CONSTANT_PROJECT_NAME}KIFUITests" "${PROJECT_NAME_NO_SPACES}KIFUITests"
-
-# Rename app folder structure
-rename_folder "${CONSTANT_PROJECT_NAME}" "${PROJECT_NAME_NO_SPACES}"
-
-# Duplicate the env example file and rename it to env file
-cp "./.env.example" "./.env"
-
-# Add AutoMockable.generated.swift file
-mkdir -p "${PROJECT_NAME_NO_SPACES}Tests/Sources/Mocks/Sourcery"
-touch "${PROJECT_NAME_NO_SPACES}Tests/Sources/Mocks/Sourcery/AutoMockable.generated.swift"
-
-# Add R.generated.swift file
-mkdir -p "${PROJECT_NAME_NO_SPACES}/Sources/Supports/Helpers/Rswift"
-touch "${PROJECT_NAME_NO_SPACES}/Sources/Supports/Helpers/Rswift/R.generated.swift"
-
-echo "✅  Completed"
-
-# Search and replace in files
-echo "=> 🔎 Replacing package and package name within files..."
-BUNDLE_ID_PRODUCTION_ESCAPED="${bundle_id_production//./\.}"
-BUNDLE_ID_STAGING_ESCAPED="${bundle_id_staging//./\.}"
-LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_BUNDLE_STAGING/$BUNDLE_ID_STAGING_ESCAPED/g" {} +
-LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_BUNDLE_PRODUCTION/$BUNDLE_ID_PRODUCTION_ESCAPED/g" {} +
-LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_PROJECT_NAME/$PROJECT_NAME_NO_SPACES/g" {} +
-LC_ALL=C find $WORKING_DIR -type f -exec sed -i "" "s/$CONSTANT_MINIMUM_VERSION/$minimum_version/g" {} +
-echo "✅  Completed"
-
-# check for tuist and install
-if ! command -v tuist &> /dev/null
-then
-    echo "Tuist could not be found"
-    echo "Installing tuist"
-    readonly TUIST_VERSION=`cat .tuist-version`
-    curl -Ls https://install.tuist.io | bash
-    tuist install ${TUIST_VERSION}
-fi
-
-# Generate with tuist
-echo "Tuist found"
-tuist generate --no-open
-echo "✅  Completed"
-
-# Install dependencies
-echo "Installing gems"
-bundle install
-
-echo "Run Arkana"
-bundle exec arkana
-
-echo "Installing pod dependencies"
-bundle exec pod install --repo-update
-echo "✅  Completed"
-
-# Remove gitkeep files
-echo "Remove gitkeep files from project"
-sed -i "" "s/.*\(gitkeep\).*,//" $PROJECT_NAME_NO_SPACES.xcodeproj/project.pbxproj
-echo "✅  Completed"
-
-# Remove Tuist files
-echo "Remove tuist files"
-rm -rf .tuist-version
-rm -rf tuist
-rm -rf Project.swift
-rm -rf Workspace.swift
-
-# Remove script files and git/index
-echo "Remove script files and git/index"
-rm -rf make.sh
-rm -rf .github/workflows/test_install_script.yml
-rm -f .git/index
-git reset
-
-if [[ -z "${CI}" ]]; then
-    rm -rf fastlane/Tests
-    rm -f set_up_test_testflight.sh
-    cat Scripts/Swift/SetUpCICDService.swift Scripts/Swift/Extensions/FileManager+Utils.swift Scripts/Swift/Helpers/SafeShell.swift > t.swift && swift t.swift && rm -rf 't.swift'
-    cat Scripts/Swift/SetUpDeliveryConstants.swift Scripts/Swift/Extensions/FileManager+Utils.swift Scripts/Swift/Helpers/SafeShell.swift > t.swift && swift t.swift && rm -rf 't.swift'
-    rm -rf Scripts
-fi
-
-
-echo "✅  Completed"
-
-# Done!
-echo "=> 🚀 Done! App is ready to be tested 🙌"
-
-if [[ -z "${CI}" ]]; then
-    echo "=> 🛠 Opening the project."
-    open -a Xcode $PROJECT_NAME_NO_SPACES.xcworkspace
-fi
+cat Scripts/Swift/SetUpiOSProject.swift Scripts/Swift/SetUpInterface.swift Scripts/Swift/Extensions/FileManager+Utils.swift Scripts/Swift/Extensions/String+Utils.swift Scripts/Swift/Helpers/SafeShell.swift > t.swift && swift t.swift $bundle_id_production $bundle_id_staging $project_name "$minimum_version" $interface && rm -rf 't.swift'

--- a/make.sh
+++ b/make.sh
@@ -35,11 +35,6 @@ project_name=""
 minimum_version=""
 interface=""
 
-readonly CONSTANT_PROJECT_NAME="{PROJECT_NAME}"
-readonly CONSTANT_BUNDLE_PRODUCTION="{BUNDLE_ID_PRODUCTION}"
-readonly CONSTANT_BUNDLE_STAGING="{BUNDLE_ID_STAGING}"
-readonly CONSTANT_MINIMUM_VERSION="{TARGET_VERSION}"
-
 while [ $# -gt 0 ] ; do
     case "$1" in
     -h|--help)


### PR DESCRIPTION
- Close #494

## What happened 👀

Migrate make.sh to Swift Command Line

## Insight 📝

- Keep `make.sh` for running the project with minimal change to command. Will be removed in #495 
- Add `copy` and `createDirectory` in `FileManager`.
- Add regex `~=` matcher to `String`.
- Move `SetUpCICDService` to struct to be called by `SetUpIOSProject`.
- Move `SetUpDeliveryConstants` to struct to be called by `SetUpIOSProject`.
- Move `SetUpInterface` to struct to be called by `SetUpIOSProject`.
- Create `SetUpIOSProject.swift` which will replace `make.sh`

## Proof Of Work 📹

Projects build successfully and CICD test works.