### PR TITLE
[#517] Fix: UI test crashed in initial run for SwiftUI project

### DIFF
--- a/Tuist/Interfaces/UIKit/Sources/Presentation/Modules/HomeViewController.swift
+++ b/Tuist/Interfaces/UIKit/Sources/Presentation/Modules/HomeViewController.swift
@@ -7,7 +7,7 @@ final class HomeViewController: UIViewController {
         view.backgroundColor = .white
 
         let helloLabel = UILabel()
-        helloLabel.text = "Hello"
+        helloLabel.text = "Hello, world!"
         helloLabel.translatesAutoresizingMaskIntoConstraints = false
 
         view.addSubview(helloLabel)

--- a/{PROJECT_NAME}KIFUITests/Sources/Specs/Application/ApplicationSpec.swift
+++ b/{PROJECT_NAME}KIFUITests/Sources/Specs/Application/ApplicationSpec.swift
@@ -23,7 +23,7 @@ final class ApplicationSpec: QuickSpec {
             context("when opens") {
 
                 it("shows its UI components") {
-                    self.tester().waitForView(withAccessibilityLabel: "Hello")
+                    self.tester().waitForView(withAccessibilityLabel: "Hello, world!")
                 }
             }
         }


### PR DESCRIPTION
- Close #517 

## What happened 👀

- Update UI test's searching label's text

## Insight 📝

- Previously UI test waited for wrong text to appear in screen, now the texts are matched and the error is gone

## Proof Of Work 📹

- Test done on main branch as develop branch got hanged while installing dependencies 

<img width="860" alt="Screenshot 2023-08-28 at 12 44 10 PM" src="https://github.com/nimblehq/ios-templates/assets/13636465/a088e338-6de1-48c7-86de-84a343726e07">

