### PR TITLE
[#482] Migrate Quick/Nimble tests to Quick 7

### DIFF
--- a/Tuist/Interfaces/SwiftUI/Project/Podfile
+++ b/Tuist/Interfaces/SwiftUI/Project/Podfile
@@ -3,8 +3,8 @@ use_frameworks!
 inhibit_all_warnings!
 
 def testing_pods
-  pod 'Quick', '~> 6.0'
-  pod 'Nimble', '~> 11.0'
+  pod 'Quick', '~> 7.0'
+  pod 'Nimble', '~> 12.0'
   pod 'Sourcery'
   pod 'SwiftFormat/CLI'
   pod 'OHHTTPStubs/Swift', :configurations => ['Debug Staging', 'Debug Production']

--- a/Tuist/Interfaces/UIKit/Project/Podfile
+++ b/Tuist/Interfaces/UIKit/Project/Podfile
@@ -3,8 +3,8 @@ use_frameworks!
 inhibit_all_warnings!
 
 def testing_pods
-  pod 'Quick', '~> 6.0'
-  pod 'Nimble', '~> 11.0'
+  pod 'Quick', '~> 7.0'
+  pod 'Nimble', '~> 12.0'
   pod 'Sourcery'
   pod 'SwiftFormat/CLI'
   pod 'OHHTTPStubs/Swift', :configurations => ['Debug Staging', 'Debug Production']

--- a/{PROJECT_NAME}KIFUITests/Sources/Specs/Application/ApplicationSpec.swift
+++ b/{PROJECT_NAME}KIFUITests/Sources/Specs/Application/ApplicationSpec.swift
@@ -6,9 +6,9 @@ import Foundation
 import Nimble
 import Quick
 
-final class ApplicationSpec: QuickSpec {
+final class ApplicationSpec: KIFSpec {
 
-    override func spec() {
+    override class func spec() {
 
         describe("a {PROJECT_NAME} screen") {
 
@@ -23,7 +23,7 @@ final class ApplicationSpec: QuickSpec {
             context("when opens") {
 
                 it("shows its UI components") {
-                    self.tester().waitForView(withAccessibilityLabel: "Hello, world!")
+                    tester().waitForView(withAccessibilityLabel: "Hello, world!")
                 }
             }
         }

--- a/{PROJECT_NAME}KIFUITests/Sources/Utilities/KIF+Swift.swift
+++ b/{PROJECT_NAME}KIFUITests/Sources/Utilities/KIF+Swift.swift
@@ -5,13 +5,13 @@
 
 import KIF
 
-extension XCTestCase {
+extension KIFSpec {
 
-    func tester(file: String = #file, _ line: Int = #line) -> KIFUITestActor {
-        return KIFUITestActor(inFile: file, atLine: line, delegate: self)
+    static func tester(file: String = #file, _ line: Int = #line) -> KIFUITestActor {
+        return KIFUITestActor(inFile: file, atLine: line, delegate: kifDelegate)
     }
 
-    func system(file: String = #file, _ line: Int = #line) -> KIFSystemTestActor {
-        return KIFSystemTestActor(inFile: file, atLine: line, delegate: self)
+    static func system(file: String = #file, _ line: Int = #line) -> KIFSystemTestActor {
+        return KIFSystemTestActor(inFile: file, atLine: line, delegate: kifDelegate)
     }
 }

--- a/{PROJECT_NAME}KIFUITests/Sources/Utilities/KIFSpec.swift
+++ b/{PROJECT_NAME}KIFUITests/Sources/Utilities/KIFSpec.swift
@@ -1,0 +1,10 @@
+//
+//  KIFSpec.swift
+//
+
+import Quick
+
+class KIFSpec: QuickSpec {
+
+    static let kifDelegate = XCTestCase()
+}

--- a/{PROJECT_NAME}Tests/Sources/Specs/Data/NetworkAPI/NetworkAPISpec.swift
+++ b/{PROJECT_NAME}Tests/Sources/Specs/Data/NetworkAPI/NetworkAPISpec.swift
@@ -9,7 +9,7 @@ import Quick
 
 final class NetworkAPISpec: QuickSpec {
 
-    override func spec() {
+    override class func spec() {
 
         describe("a NetworkAPI") {
 

--- a/{PROJECT_NAME}Tests/Sources/Specs/Data/NetworkAPI/NetworkAPISpec.swift
+++ b/{PROJECT_NAME}Tests/Sources/Specs/Data/NetworkAPI/NetworkAPISpec.swift
@@ -7,7 +7,7 @@ import Quick
 
 @testable import {PROJECT_NAME}
 
-final class NetworkAPISpec: QuickSpec {
+final class NetworkAPISpec: AsyncSpec {
 
     override class func spec() {
 

--- a/{PROJECT_NAME}Tests/Sources/Specs/Supports/Extensions/Foundation/OptionalUnwrapSpec.swift
+++ b/{PROJECT_NAME}Tests/Sources/Specs/Supports/Extensions/Foundation/OptionalUnwrapSpec.swift
@@ -9,7 +9,7 @@ import Quick
 
 final class OptionalUnwrapSpec: QuickSpec {
 
-    override func spec() {
+    override class func spec() {
 
         describe("an string optional") {
             var value: String?


### PR DESCRIPTION
- Close #482 

## What happened 👀

Update Quick and Nimble to Quick 7 and Nimble 12.

## Insight 📝

- [Quick 7](https://github.com/Quick/Quick/releases/tag/v7.0.0) supports async and non-async explicitly.
  - Make default spec same as Quick 5 which we all like 😄 
- Update KIF spec to match Quick 7. 
- No more thread complain.

## Proof Of Work 📹



https://github.com/nimblehq/ios-templates/assets/6356137/2a3b794c-21f1-4258-9882-d7b0f8187acb


