### PR TITLE
[#528] Update Default timeout for Keychain to `no time-out`

### DIFF
--- a/fastlane/Helpers/Keychain.swift
+++ b/fastlane/Helpers/Keychain.swift
@@ -16,7 +16,7 @@ enum Keychain {
             password: Secret.keychainPassword,
             defaultKeychain: .userDefined(true),
             unlock: .userDefined(true),
-            timeout: 0
+            timeout: 115_200
         )
     }
     

--- a/fastlane/Helpers/Keychain.swift
+++ b/fastlane/Helpers/Keychain.swift
@@ -16,7 +16,7 @@ enum Keychain {
             password: Secret.keychainPassword,
             defaultKeychain: .userDefined(true),
             unlock: .userDefined(true),
-            timeout: 3600
+            timeout: 0
         )
     }
     


### PR DESCRIPTION
- Close #528

## What happened 👀

Update timeout for keychain to no 1.2 days.

## Insight 📝

- I decided to use 1.2 days instead of no time-out because I have concern with keychains that never gets deleted could be remotely hacked.
- There will be a timer to remove keychains nightly on self-hosted.

## Proof Of Work 📹

This keychain had been unlocked for 2 hr+.

<img width="132" alt="Screenshot 2023-10-05 at 13 06 41" src="https://github.com/nimblehq/ios-templates/assets/6356137/8a6946b7-d7c9-478b-adab-49ae32075b12">
