### PR TITLE
[#522] Replace Firebase Token with Google Service Account

### DIFF
--- a/.github/project_workflows/deploy_production_firebase.yml
+++ b/.github/project_workflows/deploy_production_firebase.yml
@@ -3,7 +3,7 @@ name: Deploy Production Build To Firebase
 # SECRETS needed:
 ### SSH_PRIVATE_KEY for Match Repo
 ### MATCH_PASS
-### FIREBASE_TOKEN
+### FIREBASE_GOOGLE_APPLICATION_CREDENTIALS_BASE64
 
 on:
   push:
@@ -50,6 +50,13 @@ jobs:
         touch .env
         echo $ENV | base64 --decode > .env
 
+    - name: Read Google Service Account
+      id: firebase_service_account
+      uses: timheuer/base64-to-file@v1.2
+      with:
+        fileName: 'firebase_service_account.json'
+        encodedString: ${{ secrets.FIREBASE_GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
+
     - name: Bundle install
       run: bundle install
       
@@ -80,7 +87,7 @@ jobs:
     - name: Build Production App and Distribute to Firebase
       run: bundle exec fastlane buildProductionAndUploadToFirebase
       env:
-        FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.firebase_service_account.outputs.filePath }}
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v3

--- a/.github/project_workflows/deploy_staging_firebase.yml
+++ b/.github/project_workflows/deploy_staging_firebase.yml
@@ -3,7 +3,7 @@ name: Deploy Staging Build To Firebase
 # SECRETS needed:
 ### SSH_PRIVATE_KEY for Match Repo
 ### MATCH_PASS
-### FIREBASE_TOKEN
+### FIREBASE_GOOGLE_APPLICATION_CREDENTIALS_BASE64
 
 on:
   push:
@@ -55,6 +55,13 @@ jobs:
         touch .env
         echo $ENV | base64 --decode > .env
 
+    - name: Read Google Service Account
+      id: firebase_service_account
+      uses: timheuer/base64-to-file@v1.2
+      with:
+        fileName: 'firebase_service_account.json'
+        encodedString: ${{ secrets.FIREBASE_GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
+
     - name: Bundle install
       # if: steps.bundleCache.outputs.cache-hit != 'true'
       run: bundle install
@@ -86,7 +93,7 @@ jobs:
     - name: Build App and Distribute to Firebase
       run: bundle exec fastlane buildStagingAndUploadToFirebase
       env:
-        FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.firebase_service_account.outputs.filePath }}
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v3

--- a/.github/wiki/CodeMagic.md
+++ b/.github/wiki/CodeMagic.md
@@ -33,7 +33,7 @@ Out of the box, the CodeMagic Template has the following workflows and steps:
 | MATCH_PASSWORD              | The password is used to encrypt/decrypt the Match repository to store the distribution certificates and provisioning profiles. |
 | MATCH_SSH_KEY               | The SSH private key is used for cloning the Match repository that contains your distribution certificates and provisioning. |
 | KEYCHAIN_PASSWORD           | The password to access the keychain.                         |
-| FIREBASE_CLI_TOKEN          | [Firebase token](https://firebase.google.com/docs/cli#cli-ci-systems) for uploading build to Firebase Distributions and Analytics. |
+| FIREBASE_SERVICE_ACCOUNT    | [Google Service Firebase Account](https://firebase.google.com/docs/app-distribution/ios/distribute-fastlane#service-acc-fastlane) for uploading build to Firebase Distributions and Analytics. |
 | APPSTORE_CONNECT_API_KEY    | [App Store Connect API](https://docs.fastlane.tools/actions/app_store_connect_api_key/) for uploading build to TestFlight or App Store. It should be `base64` encoded. |
 | API_KEY_ID                  | The key identifier of your App Store Connect API key.        |
 | ISSUER_ID                   | The issuer of your App Store Connect API key.                |

--- a/.github/wiki/Github-Actions.md
+++ b/.github/wiki/Github-Actions.md
@@ -53,7 +53,7 @@ Make sure the following secrets are set up.
 |SSH_PRIVATE_KEY         |SSH key connected to a user with access to the match repo for check out the match repo.                                             |-   |✅              |✅                      |✅                                  |
 |MATCH_PASS              |Fastlane Match Passphrase for decrypting a match repository.                                                                        |-   |✅              |✅                      |✅                                  |
 |APPSTORE_CONNECT_API_KEY|App Store Connect API https://docs.fastlane.tools/actions/app_store_connect_api_key/ for uploading build to TestFlight or App Store. Should be `base64` encoded.|-   |-              |-                      |✅                                  |
-|FIREBASE_TOKEN          |Firebase token https://firebase.google.com/docs/cli#cli-ci-systems for uploading build to Firebase Distributions and Analytics.     |-   |✅              |✅                      |✅ For uploading dSYM to Crashlytics|
+|FIREBASE_GOOGLE_APPLICATION_CREDENTIALS_BASE64|Google Service Firebase Account https://firebase.google.com/docs/app-distribution/ios/distribute-fastlane#service-acc-fastlane for uploading build to Firebase Distributions and Analytics. Should be `base64` encoded.|-   |✅              |✅                      |✅ For uploading dSYM to Crashlytics|
 
 ## Installation
 

--- a/.github/workflows/test_upload_build_to_firebase.yml
+++ b/.github/workflows/test_upload_build_to_firebase.yml
@@ -3,7 +3,7 @@ name: Test Upload Build to Firebase
 # SECRETS needed:
 ### SSH_PRIVATE_KEY for Match Repo
 ### MATCH_PASS
-### FIREBASE_TOKEN
+### FIREBASE_GOOGLE_APPLICATION_CREDENTIALS_BASE64
 ### STAGING_FIREBASE_APP_ID
 ### TEAM_ID
 
@@ -33,6 +33,13 @@ jobs:
       run: |
         yarn global add firebase-tools
         echo "$(yarn global bin)" >> $GITHUB_PATH
+
+    - name: Read Google Service Account
+      id: firebase_service_account
+      uses: timheuer/base64-to-file@v1.2
+      with:
+        fileName: 'firebase_service_account.json'
+        encodedString: ${{ secrets.FIREBASE_GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
 
     - name: Bundle install
       run: bundle install
@@ -67,7 +74,7 @@ jobs:
     - name: Build App and Distribute to Firebase
       run: bundle exec fastlane buildStagingAndUploadToFirebase
       env:
-        FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.firebase_service_account.outputs.filePath }}
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v3

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -7,6 +7,7 @@ workflows:
           - fastlane
         xcode: latest
         cocoapods: default
+        firebase_service_account: $FIREBASE_SERVICE_ACCOUNT
       cache:
         cache_paths:
           - $HOME/Library/Caches/CocoaPods
@@ -71,6 +72,7 @@ workflows:
           - fastlane
         xcode: latest
         cocoapods: default
+        firebase_service_account: $FIREBASE_SERVICE_ACCOUNT
       cache:
         cache_paths:
           - $HOME/Library/Caches/CocoaPods

--- a/fastlane/Constants/Secret.swift
+++ b/fastlane/Constants/Secret.swift
@@ -11,8 +11,6 @@ enum Secret {
 
     static let keychainPassword = EnvironmentParser.string(key: "KEYCHAIN_PASSWORD")
 
-    static let firebaseCLIToken = EnvironmentParser.string(key: "FIREBASE_TOKEN")
-
     static let appstoreConnectAPIKey = EnvironmentParser.string(key: "APPSTORE_CONNECT_API_KEY")
 
     static let appStoreKeyIdKey = EnvironmentParser.string(key: "API_KEY_ID")

--- a/fastlane/Helpers/Distribution.swift
+++ b/fastlane/Helpers/Distribution.swift
@@ -21,7 +21,6 @@ enum Distribution {
             app: .userDefined(environment.firebaseAppId),
             groups: .userDefined(groups),
             releaseNotes: .userDefined(releaseNotes),
-            firebaseCliToken: .userDefined(Secret.firebaseCLIToken),
             debug: .userDefined(true)
         )
     }


### PR DESCRIPTION
- Close #522

## What happened 👀

- Replace `FIREBASE_TOKEN` from all workflows Secrets and use `FIREBASE_GOOGLE_APPLICATION_CREDENTIALS` instead.

## Insight 📝

- Update test workflow to use `FIREBASE_GOOGLE_APPLICATION_CREDENTIALS` as well.
- Not sure for `CodeMagic` and `Bitrise`
  - For `CodeMagic`, I used this [document](https://docs.codemagic.io/partials/firebase-authentication-service-account/).
  - For `Bitrise` it seems to be passable from the file upload section. https://devcenter.bitrise.io/en/connectivity/connecting-to-services/connecting-a-google-service-account-to-bitrise.html.  There is no `FIREBASE_TOKEN` declared in the current `Bitrise.yml` so I didn't change it.

## Proof Of Work 📹

Firebase test workflow works.

<img width="973" alt="Screenshot 2023-10-09 at 16 02 30" src="https://github.com/nimblehq/ios-templates/assets/6356137/aa77fa12-2b1a-4038-b5f4-810ad1a18bc8">
<img width="711" alt="Screenshot 2023-10-09 at 16 04 26" src="https://github.com/nimblehq/ios-templates/assets/6356137/8ff8693a-2799-40a5-9694-d9a758a89d91">

