### PR TITLE
[#548] [Chore] Fix lints after generating project

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,5 +1,5 @@
 # file options
---exclude Pods, Generated, **/*.generated.swift, fastlane/swift
+--exclude Pods, Generated, **/*.generated.swift, fastlane/swift, ArkanaKeys
 
 # rules
 --disable fileHeader

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,9 +9,9 @@ excluded:
   - Pods
   - Derived
   - DerivedData
+  - ArkanaKeys
 
 opt_in_rules:
-  - anyobject_protocol
   - array_init
   - attributes
   - closure_body_length

--- a/fastlane/Constants/Constant.swift
+++ b/fastlane/Constants/Constant.swift
@@ -119,14 +119,14 @@ extension Constant {
             let outputDirectoryURL = URL(fileURLWithPath: Constant.outputPath)
             return outputDirectoryURL.appendingPathComponent(productName + ".app" + Constant.dSYMSuffix).relativePath
         }
-        
+
         var appleUsername: String {
             switch self {
             case .staging: return Constant.appleStagingUserName
             case .production: return Constant.appleProductionUserName
             }
         }
-        
+
         var appleTeamId: String {
             switch self {
             case .staging: return Constant.appleStagingTeamId
@@ -142,7 +142,7 @@ extension Constant {
         case appStore = "app-store"
 
         var value: String { return rawValue }
-        
+
         var match: String {
             switch self {
             case .development: return "development"
@@ -150,21 +150,21 @@ extension Constant {
             case .appStore: return "appstore"
             }
         }
-        
+
         var configuration: String {
             switch self {
             case .development: return "Debug"
             case .adHoc, .appStore: return "Release"
             }
         }
-        
+
         var codeSignIdentity: String {
             switch self {
             case .development: return "iPhone Developer"
-            case .adHoc, . appStore: return "iPhone Distribution"
+            case .adHoc, .appStore: return "iPhone Distribution"
             }
         }
-        
+
         var method: String {
             switch self {
             case .development: return "Development"

--- a/fastlane/Fastfile.swift
+++ b/fastlane/Fastfile.swift
@@ -19,7 +19,7 @@ class Fastfile: LaneFile {
             environment: .staging
         )
     }
-    
+
     func syncDevelopmentProductionCodeSigningLane() {
         desc("Sync the Development match signing for the Production build")
         Match.syncCodeSigning(
@@ -51,7 +51,7 @@ class Fastfile: LaneFile {
             environment: .production
         )
     }
-    
+
     func removeKeychainLane() {
         desc("Delete keychain")
         Keychain.remove()

--- a/fastlane/Helpers/Keychain.swift
+++ b/fastlane/Helpers/Keychain.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-	
+
 enum Keychain {
 
     static func create() {
@@ -19,7 +19,7 @@ enum Keychain {
             timeout: 115_200
         )
     }
-    
+
     static func remove() {
         deleteKeychain(
             name: .userDefined(Constant.keychainName)

--- a/fastlane/Helpers/Match.swift
+++ b/fastlane/Helpers/Match.swift
@@ -35,7 +35,7 @@ enum Match {
         }
         updateCodeSigning(type: type, environment: environment)
     }
-    
+
     static func updateCodeSigning(type: Constant.BuildType, environment: Constant.Environment) {
         // Update Code signing from automatic to manual
         updateCodeSigningSettings(
@@ -43,16 +43,16 @@ enum Match {
             useAutomaticSigning: .userDefined(false),
             teamId: .userDefined(environment.appleTeamId),
             targets: .userDefined([Constant.projectName]),
-            buildConfigurations: .userDefined([Self.createBuildConfiguration(type: type, environment: environment)]),
+            buildConfigurations: .userDefined([createBuildConfiguration(type: type, environment: environment)]),
             codeSignIdentity: .userDefined(type.codeSignIdentity),
-            profileName: .userDefined(Self.createProfileName(type: type, environment: environment))
+            profileName: .userDefined(createProfileName(type: type, environment: environment))
         )
     }
-    
+
     static func createBuildConfiguration(type: Constant.BuildType, environment: Constant.Environment) -> String {
         "\(type.configuration) \(environment.rawValue)"
     }
-    
+
     static func createProfileName(type: Constant.BuildType, environment: Constant.Environment) -> String {
         "match \(type.method) \(environment.bundleId)"
     }

--- a/{PROJECT_NAME}KIFUITests/Sources/Utilities/KIF+Swift.swift
+++ b/{PROJECT_NAME}KIFUITests/Sources/Utilities/KIF+Swift.swift
@@ -8,10 +8,10 @@ import KIF
 extension KIFSpec {
 
     static func tester(file: String = #file, _ line: Int = #line) -> KIFUITestActor {
-        return KIFUITestActor(inFile: file, atLine: line, delegate: kifDelegate)
+        KIFUITestActor(inFile: file, atLine: line, delegate: kifDelegate)
     }
 
     static func system(file: String = #file, _ line: Int = #line) -> KIFSystemTestActor {
-        return KIFSystemTestActor(inFile: file, atLine: line, delegate: kifDelegate)
+        KIFSystemTestActor(inFile: file, atLine: line, delegate: kifDelegate)
     }
 }

--- a/{PROJECT_NAME}Tests/Sources/Specs/Data/NetworkAPI/NetworkAPISpec.swift
+++ b/{PROJECT_NAME}Tests/Sources/Specs/Data/NetworkAPI/NetworkAPISpec.swift
@@ -11,6 +11,7 @@ final class NetworkAPISpec: AsyncSpec {
 
     override class func spec() {
 
+        // swiftlint:disable closure_body_length
         describe("a NetworkAPI") {
 
             var networkAPI: NetworkAPI!
@@ -60,5 +61,6 @@ final class NetworkAPISpec: AsyncSpec {
                 }
             }
         }
+        // swiftlint:enable closure_body_length
     }
 }


### PR DESCRIPTION
- Close #548 

## What happened 👀

- Added ArkanaKeys in Swiftlint and swiftformat
- Removed `anyobject_protocol ` in Swiftlint
- Fixed all lints which trigger swiftlint and swiftformat on the app

## Insight 📝

- There are warnings left from Cocoapod for Sourcery, Swiftlint, and SwiftFormat. They may come from CocoaPods, there's [a thread](https://stackoverflow.com/questions/74012563/warning-build-run-script-build-phase-module-will-be-run-during-every-build-be) with solutions, but these warnings do not trigger the swiftlint and swiftformat so I think we can leave them for now

## Proof Of Work 📹

I generated a new project:

![Screenshot 2023-11-29 at 23 45 58](https://github.com/nimblehq/ios-templates/assets/25881847/652ccd57-256b-4ef5-bfb1-11da895377a3)


