### PR TITLE
[#572] Fix: Mismatching bundle Id

### DIFF
--- a/Scripts/Swift/iOSTemplateMaker/Sources/iOSTemplateMaker/SetUpiOSProject.swift
+++ b/Scripts/Swift/iOSTemplateMaker/Sources/iOSTemplateMaker/SetUpiOSProject.swift
@@ -104,7 +104,7 @@ class SetUpIOSProject {
 
         if bundleIdStaging.isEmpty {
             tryMoveDown()
-            bundleIdProduction = ask(
+            bundleIdStaging = ask(
                 "Which is the bundle ID for the staging environment?",
                 note: "Ex: com.example.project.staging",
                 onValidate: validatePackageName


### PR DESCRIPTION
- Close #572 

## What happened 👀

This PR fixes a critical bug in the project setup script (`SetUpiOSProject.swift`) where the input for the **Staging** Bundle ID was incorrectly assigned to the **Production** Bundle ID variable.

**Change:**
* Updated the assignment logic to store the user's input for the "Staging environment" into `bundleIdStaging` instead of `bundleIdProduction`.

## Insight 📝

**Why this solution?**
This appears to be a copy-paste error. The prompt explicitly asks the user: *"Which is the bundle ID for the staging environment?"*, but the code was writing the result to `bundleIdProduction`. This causes a mismatch where the Staging ID overwrites the Production ID (or vice versa depending on the flow), resulting in generated projects having incorrect bundle identifiers for their environments.

## Proof Of Work 📹

<img width="639" height="405" alt="Screenshot 2025-12-01 at 15 12 54" src="https://github.com/user-attachments/assets/13816628-13e1-4fa8-ae78-3a43a4761645" />
<img width="690" height="383" alt="Screenshot 2025-12-01 at 15 12 57" src="https://github.com/user-attachments/assets/ef6e2172-d0c3-4ab1-bcf7-d3fddfa8277a" />
<img width="626" height="450" alt="Screenshot 2025-12-01 at 15 13 02" src="https://github.com/user-attachments/assets/0944c271-6ce2-47f9-a18b-ff519cd7d271" />

