### PR TITLE
[#587 ] Fix: CI/CD Workflows Failing due to Deprecated GitHub Actions (v3)

### DIFF
--- a/.github/project_workflows/add_device_profile.yml
+++ b/.github/project_workflows/add_device_profile.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: macOS-latest
     steps:
     - name: Checkout the repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 

--- a/.github/project_workflows/automatic_pull_request_review.yml
+++ b/.github/project_workflows/automatic_pull_request_review.yml
@@ -13,11 +13,11 @@ jobs:
     name: Pull request review by Danger
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       id: bunlderCache
       with:
         path: vendor/bundle
@@ -39,7 +39,7 @@ jobs:
       run: bundle exec arkana
 
     - name: Cache Pods
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cocoapodCache
       with:
         path: Pods

--- a/.github/project_workflows/create_release_pull_request_and_bump_version.yml
+++ b/.github/project_workflows/create_release_pull_request_and_bump_version.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get release version
         run: |
@@ -56,7 +56,7 @@ jobs:
           branch: chore/bump-version-to-${{ github.event.inputs.nextVersion }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: chore/bump-version-to-${{ github.event.inputs.nextVersion }}
 

--- a/.github/project_workflows/deploy_app_store.yml
+++ b/.github/project_workflows/deploy_app_store.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -36,7 +36,7 @@ jobs:
     runs-on: macOS-latest
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     # Set fetch-depth (default: 1) to get whole tree
       with:
         fetch-depth: 0
@@ -60,7 +60,7 @@ jobs:
       run: bundle exec arkana
 
     - name: Cache Pods
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cocoapodCache
       with:
         path: Pods
@@ -89,7 +89,7 @@ jobs:
         BUMP_APP_STORE_BUILD_NUMBER: "true"
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
         path: |

--- a/.github/project_workflows/deploy_production_firebase.yml
+++ b/.github/project_workflows/deploy_production_firebase.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -39,7 +39,7 @@ jobs:
     name: Build
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     # Set fetch-depth (default: 1) to get whole tree
       with:
         fetch-depth: 0
@@ -70,7 +70,7 @@ jobs:
       run: bundle exec arkana
 
     - name: Cache Pods
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cocoapodCache
       with:
         path: Pods
@@ -96,7 +96,7 @@ jobs:
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.firebase_service_account.outputs.filePath }}
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
         path: |

--- a/.github/project_workflows/deploy_staging_firebase.yml
+++ b/.github/project_workflows/deploy_staging_firebase.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -33,7 +33,7 @@ jobs:
     name: Build
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     # Set fetch-depth (default: 1) to get whole tree
       with:
         fetch-depth: 0
@@ -76,7 +76,7 @@ jobs:
       run: bundle exec arkana
 
     - name: Cache Pods
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: cocoapodCache
       with:
         path: Pods
@@ -102,7 +102,7 @@ jobs:
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.firebase_service_account.outputs.filePath }}
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
         path: |

--- a/.github/self_hosted_project_workflows/automatic_pull_request_review.yml
+++ b/.github/self_hosted_project_workflows/automatic_pull_request_review.yml
@@ -13,11 +13,11 @@ jobs:
     name: Pull request review by Danger
     runs-on: [self-hosted, macOS]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       id: bunlderCache
       with:
         path: vendor/bundle
@@ -39,7 +39,7 @@ jobs:
       run: bundle exec arkana
 
     - name: Cache Pods
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cocoapodCache
       with:
         path: Pods

--- a/.github/self_hosted_project_workflows/deploy_app_store.yml
+++ b/.github/self_hosted_project_workflows/deploy_app_store.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -36,7 +36,7 @@ jobs:
     runs-on: [self-hosted, macOS]
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     # Set fetch-depth (default: 1) to get whole tree
       with:
         fetch-depth: 0
@@ -60,7 +60,7 @@ jobs:
       run: bundle exec arkana
 
     - name: Cache Pods
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cocoapodCache
       with:
         path: Pods
@@ -89,7 +89,7 @@ jobs:
         BUMP_APP_STORE_BUILD_NUMBER: "true"
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
         path: |

--- a/.github/self_hosted_project_workflows/deploy_production_firebase.yml
+++ b/.github/self_hosted_project_workflows/deploy_production_firebase.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -33,7 +33,7 @@ jobs:
     name: Build
     runs-on: [self-hosted, macOS]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     # Set fetch-depth (default: 1) to get whole tree
       with:
         fetch-depth: 0
@@ -64,7 +64,7 @@ jobs:
       run: bundle exec arkana
 
     - name: Cache Pods
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cocoapodCache
       with:
         path: Pods
@@ -90,7 +90,7 @@ jobs:
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.firebase_service_account.outputs.filePath }}
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
         path: |

--- a/.github/self_hosted_project_workflows/deploy_staging_firebase.yml
+++ b/.github/self_hosted_project_workflows/deploy_staging_firebase.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -33,7 +33,7 @@ jobs:
     name: Build
     runs-on: [self-hosted, macOS]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     # Set fetch-depth (default: 1) to get whole tree
       with:
         fetch-depth: 0
@@ -70,7 +70,7 @@ jobs:
       run: bundle exec arkana
 
     - name: Cache Pods
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: cocoapodCache
       with:
         path: Pods
@@ -96,7 +96,7 @@ jobs:
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.firebase_service_account.outputs.filePath }}
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
         path: |

--- a/.github/workflows/cleanup_cache.yml
+++ b/.github/workflows/cleanup_cache.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macOS-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Cleanup
         run: |

--- a/.github/workflows/test_swiftui_install_script.yml
+++ b/.github/workflows/test_swiftui_install_script.yml
@@ -13,7 +13,7 @@ jobs:
     name: Test
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Bundle install
       run: bundle install

--- a/.github/workflows/test_uikit_install_script.yml
+++ b/.github/workflows/test_uikit_install_script.yml
@@ -13,7 +13,7 @@ jobs:
     name: Test
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Bundle install
       run: bundle install

--- a/.github/workflows/test_upload_build_to_firebase.yml
+++ b/.github/workflows/test_upload_build_to_firebase.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: macOS-latest
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -53,7 +53,7 @@ jobs:
       run: bundle install
 
     - name: Cache Pods
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cocoapodCache
       with:
         path: Pods
@@ -85,7 +85,7 @@ jobs:
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.firebase_service_account.outputs.filePath }}
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
         path: |

--- a/.github/workflows/test_upload_build_to_test_flight.yml
+++ b/.github/workflows/test_upload_build_to_test_flight.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macOS-latest
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -35,7 +35,7 @@ jobs:
       run: bundle install
 
     - name: Cache Pods
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cocoapodCache
       with:
         path: Pods


### PR DESCRIPTION
- Close #587 

## What happened 👀

This PR updates the versions of standard GitHub Actions across all CI/CD workflow files (`project_workflows`, `self_hosted_project_workflows`, and `workflows`).

**Key Changes:**
* **Checkout:** Upgraded `actions/checkout` to `v6`.
* **Cache:** Upgraded `actions/cache` to `v4`.
* **Artifacts:** Upgraded `actions/upload-artifact` to `v4`.

## Insight 📝

**Why this solution?**
GitHub has deprecated the Node.js 12 and 16 runtimes, which are used by the older versions of these actions (v2/v3). Keeping these dependencies outdated results in deprecation warnings and will eventually cause the workflows to fail on newer runner images (like `macos-latest`).

Updating to the latest major versions ensures our CI/CD pipelines use the supported Node.js 20 runtime and remain compatible with GitHub's infrastructure.

> **Note:** Some steps in the workflow may still fail after this update. These remaining failures are unrelated to the action versions and will be resolved in a separate issue.

## Proof Of Work 📹

<img width="1727" height="634" alt="Screenshot 2025-12-03 at 10 05 47" src="https://github.com/user-attachments/assets/d394dc07-e02b-452d-838d-13604e917fa3" />

