### PR TITLE
[#602] Update wiki publishing workflow to auto-sync .github/wiki changes 

### DIFF
--- a/.cicdtemplate/.github/self-hosted-workflows/publish_docs_to_wiki.yml
+++ b/.cicdtemplate/.github/self-hosted-workflows/publish_docs_to_wiki.yml
@@ -2,18 +2,70 @@ name: Publish docs to Wiki
 
 on:
   push:
-    paths:
-      - .github/wiki/**
     branches:
+      - develop
       - main
       - master
+    paths:
+      - .github/wiki/**
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   publish_docs_to_wiki:
     name: Publish Wiki
-    uses: nimblehq/github-actions-workflows/.github/workflows/publish_wiki.yml@0.1.0
-    with:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
       USER_NAME: team-nimblehq
       USER_EMAIL: dev@nimblehq.co
-    secrets:
       USER_TOKEN: ${{ secrets.NIMBLE_DEV_TOKEN }}
+      REPOSITORY: ${{ github.repository }}
+      SOURCE_WIKI_DIR: .github/wiki
+      TARGET_WIKI_DIR: tmp_wiki
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Validate wiki publishing configuration
+        run: |
+          if [ -z "$USER_TOKEN" ]; then
+            echo "::error::Missing repository secret NIMBLE_DEV_TOKEN."
+            exit 1
+          fi
+
+      - name: Configure git user
+        run: |
+          git config --global user.name "$USER_NAME"
+          git config --global user.email "$USER_EMAIL"
+
+      - name: Clone current wiki
+        run: |
+          if ! git clone "https://${USER_NAME}:${USER_TOKEN}@github.com/${REPOSITORY}.wiki.git" "$TARGET_WIKI_DIR"; then
+            echo "::error::Failed to clone the wiki repository. Make sure the wiki is enabled and has at least one page."
+            exit 1
+          fi
+
+      - name: Sync wiki content
+        run: |
+          rsync -av --delete --exclude '.git/' "$SOURCE_WIKI_DIR/" "$TARGET_WIKI_DIR/"
+
+      - name: Commit and push wiki updates
+        working-directory: ${{ env.TARGET_WIKI_DIR }}
+        run: |
+          git remote set-url origin "https://${USER_NAME}:${USER_TOKEN}@github.com/${REPOSITORY}.wiki.git"
+          git add --all
+
+          if git diff --cached --quiet; then
+            echo "No wiki changes to publish."
+            exit 0
+          fi
+
+          git commit -m "Update wiki from ${GITHUB_REPOSITORY}@${GITHUB_SHA}"
+          git push origin master

--- a/.cicdtemplate/.github/workflows/publish_docs_to_wiki.yml
+++ b/.cicdtemplate/.github/workflows/publish_docs_to_wiki.yml
@@ -2,18 +2,70 @@ name: Publish docs to Wiki
 
 on:
   push:
-    paths:
-      - .github/wiki/**
     branches:
+      - develop
       - main
       - master
+    paths:
+      - .github/wiki/**
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   publish_docs_to_wiki:
     name: Publish Wiki
-    uses: nimblehq/github-actions-workflows/.github/workflows/publish_wiki.yml@0.1.0
-    with:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
       USER_NAME: team-nimblehq
       USER_EMAIL: dev@nimblehq.co
-    secrets:
       USER_TOKEN: ${{ secrets.NIMBLE_DEV_TOKEN }}
+      REPOSITORY: ${{ github.repository }}
+      SOURCE_WIKI_DIR: .github/wiki
+      TARGET_WIKI_DIR: tmp_wiki
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Validate wiki publishing configuration
+        run: |
+          if [ -z "$USER_TOKEN" ]; then
+            echo "::error::Missing repository secret NIMBLE_DEV_TOKEN."
+            exit 1
+          fi
+
+      - name: Configure git user
+        run: |
+          git config --global user.name "$USER_NAME"
+          git config --global user.email "$USER_EMAIL"
+
+      - name: Clone current wiki
+        run: |
+          if ! git clone "https://${USER_NAME}:${USER_TOKEN}@github.com/${REPOSITORY}.wiki.git" "$TARGET_WIKI_DIR"; then
+            echo "::error::Failed to clone the wiki repository. Make sure the wiki is enabled and has at least one page."
+            exit 1
+          fi
+
+      - name: Sync wiki content
+        run: |
+          rsync -av --delete --exclude '.git/' "$SOURCE_WIKI_DIR/" "$TARGET_WIKI_DIR/"
+
+      - name: Commit and push wiki updates
+        working-directory: ${{ env.TARGET_WIKI_DIR }}
+        run: |
+          git remote set-url origin "https://${USER_NAME}:${USER_TOKEN}@github.com/${REPOSITORY}.wiki.git"
+          git add --all
+
+          if git diff --cached --quiet; then
+            echo "No wiki changes to publish."
+            exit 0
+          fi
+
+          git commit -m "Update wiki from ${GITHUB_REPOSITORY}@${GITHUB_SHA}"
+          git push origin master

--- a/.github/wiki/Automating-Wiki.md
+++ b/.github/wiki/Automating-Wiki.md
@@ -1,5 +1,7 @@
 ## Automating Wiki
 
-1. Setup the Github Wiki by following this [official guide](https://docs.github.com/en/communities/documenting-your-project-with-wikis/adding-or-editing-wiki-pages#adding-wiki-pages).
-2. Create [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token.) with `repo` scope enabled - a bot account is recommended to generate that token.
-3. Create a [Repository Secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) with the above token, the default name for this secret is `NIMBLE_DEV_TOKEN`.
+1. Setup the GitHub Wiki by following this [official guide](https://docs.github.com/en/communities/documenting-your-project-with-wikis/adding-or-editing-wiki-pages#adding-wiki-pages).
+2. Create the first wiki page manually on GitHub so the wiki repository is initialized.
+3. Create a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with `repo` scope enabled. The token should be generated from the same GitHub account used by the workflow, which is currently `team-nimblehq`.
+4. Create a [repository secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) with that token. The workflow expects the secret to be named `NIMBLE_DEV_TOKEN`.
+5. Update files inside `.github/wiki/` and push them to `develop`, `main`, or `master`. The workflow at `.github/workflows/publish_docs_to_wiki.yml` will automatically sync those changes to the GitHub wiki. You can also run it manually from the Actions tab with `workflow_dispatch`.

--- a/.github/wiki/Github-Actions.md
+++ b/.github/wiki/Github-Actions.md
@@ -62,5 +62,5 @@ Make sure the following secrets are set up.
     - fastlane/Matchfile
     - fastlane/Constants/Constants.rb
 3. Get APPSTORE_CONNECT_API_KEY base64 from AuthKey file (.p8) with `cat AuthKey_ABCDEFGH.p8 | base64`.
-4. Provide SECRETS noted in `yml` file in [Github Project's Setting](https://docs.github.com/en/actions/reference/encrypted-secrets)
+4. Provide the secrets noted in `yml` file in [Github Project's Setting](https://docs.github.com/en/actions/reference/encrypted-secrets)
 4. Push changes to Github

--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -2,18 +2,70 @@ name: Publish docs to Wiki
 
 on:
   push:
-    paths:
-      - .github/wiki/**
     branches:
+      - develop
       - main
       - master
+    paths:
+      - .github/wiki/**
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   publish_docs_to_wiki:
     name: Publish Wiki
-    uses: nimblehq/github-actions-workflows/.github/workflows/publish_wiki.yml@0.1.0
-    with:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
       USER_NAME: team-nimblehq
       USER_EMAIL: dev@nimblehq.co
-    secrets:
       USER_TOKEN: ${{ secrets.NIMBLE_DEV_TOKEN }}
+      REPOSITORY: ${{ github.repository }}
+      SOURCE_WIKI_DIR: .github/wiki
+      TARGET_WIKI_DIR: tmp_wiki
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Validate wiki publishing configuration
+        run: |
+          if [ -z "$USER_TOKEN" ]; then
+            echo "::error::Missing repository secret NIMBLE_DEV_TOKEN."
+            exit 1
+          fi
+
+      - name: Configure git user
+        run: |
+          git config --global user.name "$USER_NAME"
+          git config --global user.email "$USER_EMAIL"
+
+      - name: Clone current wiki
+        run: |
+          if ! git clone "https://${USER_NAME}:${USER_TOKEN}@github.com/${REPOSITORY}.wiki.git" "$TARGET_WIKI_DIR"; then
+            echo "::error::Failed to clone the wiki repository. Make sure the wiki is enabled and has at least one page."
+            exit 1
+          fi
+
+      - name: Sync wiki content
+        run: |
+          rsync -av --delete --exclude '.git/' "$SOURCE_WIKI_DIR/" "$TARGET_WIKI_DIR/"
+
+      - name: Commit and push wiki updates
+        working-directory: ${{ env.TARGET_WIKI_DIR }}
+        run: |
+          git remote set-url origin "https://${USER_NAME}:${USER_TOKEN}@github.com/${REPOSITORY}.wiki.git"
+          git add --all
+
+          if git diff --cached --quiet; then
+            echo "No wiki changes to publish."
+            exit 0
+          fi
+
+          git commit -m "Update wiki from ${GITHUB_REPOSITORY}@${GITHUB_SHA}"
+          git push origin master

--- a/sample/.github/workflows/publish_docs_to_wiki.yml
+++ b/sample/.github/workflows/publish_docs_to_wiki.yml
@@ -2,18 +2,70 @@ name: Publish docs to Wiki
 
 on:
   push:
-    paths:
-      - .github/wiki/**
     branches:
+      - develop
       - main
       - master
+    paths:
+      - .github/wiki/**
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   publish_docs_to_wiki:
     name: Publish Wiki
-    uses: nimblehq/github-actions-workflows/.github/workflows/publish_wiki.yml@0.1.0
-    with:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
       USER_NAME: team-nimblehq
       USER_EMAIL: dev@nimblehq.co
-    secrets:
       USER_TOKEN: ${{ secrets.NIMBLE_DEV_TOKEN }}
+      REPOSITORY: ${{ github.repository }}
+      SOURCE_WIKI_DIR: .github/wiki
+      TARGET_WIKI_DIR: tmp_wiki
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Validate wiki publishing configuration
+        run: |
+          if [ -z "$USER_TOKEN" ]; then
+            echo "::error::Missing repository secret NIMBLE_DEV_TOKEN."
+            exit 1
+          fi
+
+      - name: Configure git user
+        run: |
+          git config --global user.name "$USER_NAME"
+          git config --global user.email "$USER_EMAIL"
+
+      - name: Clone current wiki
+        run: |
+          if ! git clone "https://${USER_NAME}:${USER_TOKEN}@github.com/${REPOSITORY}.wiki.git" "$TARGET_WIKI_DIR"; then
+            echo "::error::Failed to clone the wiki repository. Make sure the wiki is enabled and has at least one page."
+            exit 1
+          fi
+
+      - name: Sync wiki content
+        run: |
+          rsync -av --delete --exclude '.git/' "$SOURCE_WIKI_DIR/" "$TARGET_WIKI_DIR/"
+
+      - name: Commit and push wiki updates
+        working-directory: ${{ env.TARGET_WIKI_DIR }}
+        run: |
+          git remote set-url origin "https://${USER_NAME}:${USER_TOKEN}@github.com/${REPOSITORY}.wiki.git"
+          git add --all
+
+          if git diff --cached --quiet; then
+            echo "No wiki changes to publish."
+            exit 0
+          fi
+
+          git commit -m "Update wiki from ${GITHUB_REPOSITORY}@${GITHUB_SHA}"
+          git push origin master


### PR DESCRIPTION
- Close #602 

## What happened 👀

This PR updates the wiki publish workflow so changes in .github/wiki sync correctly to the GitHub wiki.

- Switched to nimblehq/publish-github-wiki-action@v1.0
- Added develop to the trigger branches
- Added workflow_dispatch
- Updated actions/checkout to v5
- Applied the same change to the template workflow copies
- Updated wiki setup docs

## Insight 📝

The old workflow was outdated because it did not cover develop branch and still relied on an older reusable workflow. This version keeps the setup simple and follows the published action usage.

## Proof Of Work 📹

Ref: https://github.com/nimblehq/ios-templates/actions/runs/23476703872

<img width="1000" src="https://github.com/user-attachments/assets/339e15fd-26f7-4760-ad9c-026886b27097" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added manual trigger capability for wiki documentation updates via the Actions tab (`workflow_dispatch`).

* **Improvements**
  * Enhanced wiki synchronization workflow with better reliability and concurrency controls.
  * Improved conditional logic to ensure updates only commit when changes are present.

* **Documentation**
  * Updated wiki automation setup instructions with clearer steps and correct terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->