### PR TITLE
[#595] Add /commit skill following Nimble Compass convention

### DIFF
--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -62,7 +62,7 @@ If the changes obviously belong to one concern, proceed without asking for appro
 
 ```bash
 git commit -m "$(cat <<'EOF'
-[#593] Refactor repo structure
+[<ID>] <Verb> <specific message>
 EOF
 )"
 ```

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: commit
+description: Generate and create a git commit following Nimble's Compass convention
+             ([#ID] Verb message). Auto-extracts issue ID from branch name.
+             Use when asked to commit the current work or create a git commit.
+---
+
+You are creating a git commit following Nimble's Compass commit convention.
+
+## Nimble Commit Convention
+
+**Format:** `[<ID>] Verb message`
+
+Rules:
+- **Verb tense:** Present imperative — "Fix", "Add", "Remove", "Update", "Refactor" (never past tense)
+- **Capitalization:** Capitalize the first word after the bracket
+- **No colon** after the bracket — just a space before the verb
+- **Periods** only when the message has multiple sentences
+- **Be specific:** Avoid generic messages like "Resolve feedback" or "Fix comments"
+- **One concern per commit:** If you'd use "and", consider two commits
+
+Examples of correct messages:
+- `[#42] Fix crash on launch when user is not authenticated`
+- `[GT-7108] Add order cancellation flow`
+- `[593] Refactor repo structure`
+- `[PROJ-100] Remove UIKit scaffolding from template`
+
+## Step 1 — Gather context
+
+Run these commands in parallel to understand the current state:
+- `git branch --show-current` — get the branch name
+- `git status` — see staged and unstaged files
+- `git diff --staged` — see what is staged
+- `git diff` — see what is unstaged
+
+## Step 2 — Determine the issue ID
+
+Extract the issue ID using this priority order:
+
+1. **Argument passed to the skill** — if the user ran `/commit 593`, use `593`
+2. **Branch name** — parse the current branch with these patterns (first match wins):
+
+   | Branch example | Extracted ID |
+   |----------------|-------------|
+   | `chore/593-refactor-repo` | `593` |
+   | `feature/GT-7108-add-login` | `GT-7108` |
+   | `fix/#42-crash-on-launch` | `#42` |
+   | `feature/PROJ-100-something` | `PROJ-100` |
+
+   Pattern: after the first `/`, match `(#?\d+|[A-Z]+-\d+)` followed by `-` or end-of-string.
+
+3. **Ask the user** only if neither source yields an ID.
+
+If the extracted ID already starts with `#` (e.g. `#42`), use it as-is. If it is a plain number (e.g. `593`), format it as `#593`. If it is a Jira-style key (e.g. `GT-7108`), use it as-is without `#`.
+
+## Step 3 — Stage and commit immediately
+
+Do **not** ask for approval. Generate the best commit message and commit straight away.
+
+1. Stage files **by name** (never use `git add -A` or `git add .`). Use `git add <file> [<file> ...]` for exactly the files that belong to this commit.
+2. Create the commit:
+
+```bash
+git commit -m "$(cat <<'EOF'
+[#593] Refactor repo structure
+EOF
+)"
+```
+
+3. Run `git log --oneline -1` and show the user the result.
+
+## Edge cases
+
+- **Skip CI:** Only prepend `[skip ci]` when the user explicitly requests it. Format: `[skip ci] [#ID] Verb message`
+- **No staged or unstaged changes:** Inform the user there is nothing to commit.
+- **Amend:** Only amend if the user explicitly asks to amend. Warn that amending a published commit rewrites history.

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -55,7 +55,7 @@ If the extracted ID already starts with `#` (e.g. `#42`), use it as-is. If it is
 
 ## Step 3 — Stage and commit immediately
 
-Do **not** ask for approval. Generate the best commit message and commit straight away.
+If the changes obviously belong to one concern, proceed without asking for approval. If the diff appears to contain multiple unrelated changes (e.g. a feature addition mixed with an unrelated bug fix or refactor), stop and ask the user how to split the commit.
 
 1. Stage files **by name** (never use `git add -A` or `git add .`). Use `git add <file> [<file> ...]` for exactly the files that belong to this commit.
 2. Create the commit:

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: commit
 description: Generate and create a git commit following Nimble's Compass convention
-             ([#ID] Verb message). Auto-extracts issue ID from branch name.
+             ([ID] Verb message). Auto-extracts issue ID from branch name.
              Use when asked to commit the current work or create a git commit.
 ---
 


### PR DESCRIPTION
- Close #595

## What happened 👀

Add a Claude Code `/commit` skill (`skills/commit/SKILL.md`) that auto-generates git commit messages following Nimble's Compass convention (`[#ID] Verb message`).

The skill:
- Auto-extracts the issue ID from the branch name (supports `#123`, `GT-7108`, `PROJ-100` patterns)
- Stages files by name (never uses `git add -A` or `git add .`)
- Commits immediately without prompting for approval
- Handles edge cases: skip CI, no changes, amend warnings

## Insight 📝

The Nimble Compass defines a strict commit message format (`[#ID] Verb message`) that is easy to get wrong under time pressure. This skill encodes those rules so the AI tool always produces compliant messages, eliminating review comments about formatting.

**Why a skill over a plain instruction?**  
Skills are invocable on demand (`/commit`) and carry their own focused context, keeping the main CLAUDE.md concise. The skill also documents the convention inline, serving as a quick reference.

**Alternatives considered:**  
- Adding commit rules directly to CLAUDE.md — rejected because it bloats the main instructions and isn't scoped to commit time.
- A shell script/git hook — rejected because it requires separate tooling setup per developer.

**How to test:**  
1. Make a change on a branch named `chore/123-some-description`
2. Run `/commit` in Claude Code
3. Verify the commit message is `[#123] <Verb> <description>`

## Proof Of Work 📹

<img width="1217" height="775" alt="CleanShot 2026-03-18 at 14 43 31" src="https://github.com/user-attachments/assets/8fef1f6b-3355-42b2-b6ea-f05e2fc9496b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added user-facing documentation for a new automated commit workflow skill: explains commit-message conventions (format, tense, capitalization, punctuation, one-change-per-commit), how the workflow gathers repository context, rules for extracting and normalizing issue IDs from inputs/branch names, explicit staging and immediate commit behavior, and handling for amend, skip-CI, and no-change edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->