### PR TITLE
[#612] Update Test Upload Dev Build to Firebase workflow to run only on develop merges

### DIFF
--- a/.github/workflows/test_upload_dev_build_to_firebase.yml
+++ b/.github/workflows/test_upload_dev_build_to_firebase.yml
@@ -7,10 +7,12 @@ name: Test Upload Dev Build to Firebase
 ### TEAM_ID
 
 on:
-  pull_request
-  
+  push:
+    branches:
+      - develop
+
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
- Close #612

## What happened 👀

Update the `Test Upload Dev Build to Firebase` workflow trigger from `on: pull_request` to `on: push` targeting the `develop` branch only.

Also simplifies the `concurrency` group key by removing the now-unused `pull_request.number` reference.

## Insight 📝

The workflow was running on every PR, triggering a full build, code signing, and Firebase distribution on each PR — which is expensive and unnecessary for most changes. Running it only on merges into `develop` ensures the dev build is still validated on integration without wasting CI resources on every PR.

## Proof Of Work 📹

N/A