### PR TITLE
[#609] Add /resolve-pr-comments skill

### DIFF
--- a/skills/resolve-pr-comments/SKILL.md
+++ b/skills/resolve-pr-comments/SKILL.md
@@ -1,0 +1,226 @@
+# resolve-pr-comments
+
+Guided workflow to address, reply to, and resolve GitHub PR review threads — one at a time, collaboratively.
+
+## Trigger
+
+Use when the user says `/resolve-pr-comments` optionally followed by a PR URL or a comment URL.
+
+---
+
+## Input
+
+The user provides either:
+- **PR URL**: `https://github.com/owner/repo/pull/123` — process all unresolved threads
+- **Comment URL**: `https://github.com/owner/repo/pull/123#discussion_r<id>` — process that single thread
+
+If no URL is provided, ask the user for one before proceeding.
+
+Extract `owner`, `repo`, and `pull_number` from the URL.
+
+---
+
+## Step 1 — Fetch threads
+
+### Single comment URL (fragment `#discussion_r<ID>`)
+
+Extract the numeric comment ID from the fragment. Use GraphQL to find the review thread that contains it:
+
+```bash
+gh api graphql -f query='
+  query {
+    repository(owner: "OWNER", name: "REPO") {
+      pullRequest(number: PR_NUM) {
+        reviewThreads(first: 100) {
+          nodes {
+            id
+            isResolved
+            path
+            diffHunk
+            comments(first: 20) {
+              nodes {
+                databaseId
+                author { login }
+                body
+                createdAt
+              }
+            }
+          }
+        }
+      }
+    }
+  }'
+```
+
+Filter to the thread whose `comments.nodes` contains a node with `databaseId == <ID>`.
+
+### PR URL (all threads)
+
+Use the same GraphQL query above. Filter to nodes where `isResolved == false`.
+
+---
+
+## Step 2 — Display thread context
+
+For each thread, display clearly:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Thread: <path>
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Diff hunk:
+<diffHunk>
+
+Comments:
+  [author] createdAt
+  > body
+
+  [author] createdAt
+  > body
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+---
+
+## Step 3 — Per-thread loop
+
+For each unresolved thread, work through these steps in order:
+
+### 3a — Analyze and propose
+
+Claude reads the file at `path` to get current context, then proposes one of:
+
+- **"No code change needed."** — explain what reply to send and why no change is required
+- **"Code change needed."** — describe the change; ask: *"Should I make this change?"*
+
+Wait for user confirmation or adjustment before proceeding.
+
+### 3b — Implement (if code change)
+
+Make the code change. **Do not commit or push yet.**
+
+### 3c — Draft commit message and reply, then confirm
+
+Compose both drafts and present them together for user approval:
+
+**Commit message:** follow the Nimble Compass convention (`[#ID] Verb message`). Derive the ID from the branch name using the same rules as the `/commit` skill.
+
+**Reply:** vary the phrasing naturally based on the nature of the comment — examples:
+  - `"Good catch, fixed in <sha>."`
+  - `"Good point, updated in <sha>."`
+  - `"Agreed, refactored in <sha>."`
+  - `"Done, updated in <sha>."`
+  - `"Fixed in <sha>."`
+  - `"Updated in <sha>."`
+  - Use your judgment — pick whichever fits the tone of the original comment. Avoid repeating the same opener across multiple threads in the same PR.
+  - Use a placeholder like `<sha>` since the commit hasn't happened yet.
+
+For a **no-code-change** reply: brief factual explanation, 1–2 sentences max. If referencing a specific piece of code, include it as a code block with a comment on the first line showing the file path, line number, and a link to that file on GitHub:
+  ````
+  ```{language inferred from file extension}
+  // {path}, line {N} — https://github.com/OWNER/REPO/blob/BRANCH/path/to/file#LN
+  relevant code here...
+  ```
+  ````
+  Use the current branch name for the link. Include only the most relevant lines — keep the snippet short.
+
+No emoji unless the user adds them.
+
+Show both drafts to the user at once:
+
+> **Commit message:** `"[#595] Fix commit description format"`
+> **Reply:** `"Good point, updated in <sha>."`
+> Does this look good?
+
+Wait for explicit approval (or edits) before proceeding.
+
+### 3d — Commit, push, then post the reply
+
+Once the user approves:
+
+1. Commit using the approved message:
+
+```bash
+git add <files> && git commit -m "APPROVED COMMIT MESSAGE"
+```
+
+2. Capture the short SHA:
+
+```bash
+git log --oneline -1
+```
+
+3. Push:
+
+```bash
+git push
+```
+
+4. Replace `<sha>` in the reply with the real short SHA, then post it:
+
+### 3e — Post the reply
+
+Use `in_reply_to` on the PR comments endpoint — more reliable than the `/replies` endpoint, which 404s when the target comment is itself a reply:
+
+```bash
+gh api repos/OWNER/REPO/pulls/PULL_NUMBER/comments \
+  -X POST \
+  -f body="REPLY TEXT" \
+  -F in_reply_to=COMMENT_DATABASE_ID
+```
+
+`COMMENT_DATABASE_ID` is the `databaseId` of the **first comment** in the thread (the root). `PULL_NUMBER` is the PR number extracted from the URL.
+
+### 3e — Mark thread resolved (conditional)
+
+Only resolve the thread if the reply is conclusive — i.e. a code fix was made, or the explanation fully closes the discussion with no open questions.
+
+**Do not resolve** if:
+- The reply asks a follow-up question or invites further discussion
+- The reply is a partial response pending reviewer confirmation
+- The user's reply draft suggests the thread should stay open
+
+Ask the user: **"Should I mark this thread as resolved?"** if it's ambiguous.
+
+When resolving:
+
+```bash
+gh api graphql -f query='
+  mutation {
+    resolveReviewThread(input: {threadId: "THREAD_NODE_ID"}) {
+      thread { isResolved }
+    }
+  }'
+```
+
+---
+
+## Step 4 — Completion
+
+After all threads are processed, report:
+
+```
+Done — X thread(s) resolved.
+```
+
+---
+
+## Reply conventions (Nimble Compass)
+
+| Situation | Reply format |
+|-----------|-------------|
+| Code changed | Vary naturally: `"Good catch, fixed in <sha>."` / `"Good point, updated in <sha>."` / `"Agreed, refactored in <sha>."` / `"Fixed in <sha>."` etc. — match the tone, don't repeat the same opener across threads |
+| No code change, explanation needed | Brief factual explanation, 1–2 sentences |
+| Declined / won't fix | Polite explanation of why, 1–2 sentences |
+
+- Never post a reply without user approval
+- No emoji unless the user uses them first
+- Keep replies short and professional
+
+---
+
+## Error handling
+
+- If a thread has already been resolved when you try to resolve it, skip silently and continue.
+- If `gh api` returns an error posting a reply, show the error and ask the user how to proceed — do not auto-retry.
+- If the PR has no unresolved threads, report that immediately and stop.

--- a/skills/resolve-pr-comments/SKILL.md
+++ b/skills/resolve-pr-comments/SKILL.md
@@ -41,7 +41,7 @@ Work through each unresolved thread collaboratively.
 
 ### Workflow: Resolve a Thread
 
-For each unresolved thread, display context then work through steps 1–7:
+For each unresolved thread, display context then work through the steps below. Steps 2–5 apply only when a code change is needed; skip them otherwise.
 
 **Display format:**
 ```
@@ -62,6 +62,23 @@ Reads the file at `path` to get current context, then proposes one of:
 - **"Code change needed."** — describe the change; ask: *"Should I make this change?"*
 
 Wait for user confirmation or adjustment before proceeding.
+
+**If no code change:** Draft the reply now, then skip to Step 6.
+
+Brief factual explanation, 1–2 sentences. If referencing a specific piece of code, first use search or read to locate the snippet and determine the correct line number(s), then include it as a code block:
+  ````
+  ```{language inferred from file extension}
+  // {path}, line {N} — https://github.com/OWNER/REPO/blob/BRANCH/path/to/file#LN
+  relevant code here...
+  ```
+  ````
+  Use the current branch name for the link. Keep the snippet short.
+
+No emoji unless the user uses them first. Wait for user approval before posting.
+
+---
+
+**If code change — continue with Steps 2–7:**
 
 #### Step 2 — Verify branch
 
@@ -92,15 +109,6 @@ Compose both drafts and present them together for user approval.
   - `"Fixed in <sha>."`
   - Avoid repeating the same opener across multiple threads in the same PR.
   - Use `<sha>` as a placeholder since the commit hasn't happened yet.
-
-**No-code-change reply:** Brief factual explanation, 1–2 sentences. If referencing a specific piece of code, first use search or read to locate the snippet and determine the correct line number(s), then include it as a code block:
-  ````
-  ```{language inferred from file extension}
-  // {path}, line {N} — https://github.com/OWNER/REPO/blob/BRANCH/path/to/file#LN
-  relevant code here...
-  ```
-  ````
-  Use the current branch name for the link. Keep the snippet short.
 
 No emoji unless the user uses them first.
 

--- a/skills/resolve-pr-comments/SKILL.md
+++ b/skills/resolve-pr-comments/SKILL.md
@@ -41,7 +41,7 @@ Work through each unresolved thread collaboratively.
 
 ### Workflow: Resolve a Thread
 
-For each unresolved thread, display context then work through steps 1–6:
+For each unresolved thread, display context then work through steps 1–7:
 
 **Display format:**
 ```
@@ -63,11 +63,22 @@ Reads the file at `path` to get current context, then proposes one of:
 
 Wait for user confirmation or adjustment before proceeding.
 
-#### Step 2 — Implement (if code change)
+#### Step 2 — Verify branch
+
+Fetch the PR's head ref and confirm the local checkout matches:
+
+```bash
+gh pr view PULL_NUMBER --repo OWNER/REPO --json headRefName --jq '.headRefName'
+git branch --show-current
+```
+
+If the two values differ, stop and tell the user: the local branch does not match the PR branch and they must switch before proceeding.
+
+#### Step 3 — Implement (if code change)
 
 Make the code change. **Do not commit or push yet.**
 
-#### Step 3 — Draft commit message and reply, then confirm
+#### Step 4 — Draft commit message and reply, then confirm
 
 Compose both drafts and present them together for user approval.
 
@@ -101,7 +112,7 @@ Show both drafts at once:
 
 Wait for explicit approval (or edits) before proceeding.
 
-#### Step 4 — Commit and push
+#### Step 5 — Commit and push
 
 Once the user approves:
 
@@ -109,7 +120,7 @@ Once the user approves:
 2. Capture the short SHA: `git log --oneline -1`
 3. Push: `git push`
 
-#### Step 5 — Post the reply
+#### Step 6 — Post the reply
 
 Replace `<sha>` in the reply with the real short SHA, then post using `in_reply_to` (more reliable than the `/replies` endpoint, which 404s when the target comment is itself a reply):
 
@@ -122,7 +133,7 @@ gh api repos/OWNER/REPO/pulls/PULL_NUMBER/comments \
 
 `COMMENT_DATABASE_ID` is the `databaseId` of the **thread's top-level comment** in the thread (oldest in the thread). `PULL_NUMBER` is the PR number extracted from the URL.
 
-#### Step 6 — Mark thread resolved (conditional)
+#### Step 7 — Mark thread resolved (conditional)
 
 Only resolve if the reply is conclusive — a code fix was made, or the explanation fully closes the discussion with no open questions.
 

--- a/skills/resolve-pr-comments/SKILL.md
+++ b/skills/resolve-pr-comments/SKILL.md
@@ -56,7 +56,7 @@ Comments:
 
 #### Step 1 — Analyze and propose
 
-Read the file at `path` to get current context, then propose one of:
+Reads the file at `path` to get current context, then proposes one of:
 
 - **"No code change needed."** — explain what reply to send and why no change is required
 - **"Code change needed."** — describe the change; ask: *"Should I make this change?"*

--- a/skills/resolve-pr-comments/SKILL.md
+++ b/skills/resolve-pr-comments/SKILL.md
@@ -1,162 +1,117 @@
+---
+name: resolve-pr-comments
+description: Guided workflow to address, reply to, and resolve GitHub PR review threads — one at a time, collaboratively. Use when the user says `/resolve-pr-comments` optionally followed by a PR URL or a comment URL.
+disable-model-invocation: true
+triggers:
+  - /resolve-pr-comments
+  - resolve PR comments
+  - address PR review
+  - respond to code review
+  - reply to PR thread
+---
+
 # resolve-pr-comments
 
 Guided workflow to address, reply to, and resolve GitHub PR review threads — one at a time, collaboratively.
 
-## Trigger
+---
 
-Use when the user says `/resolve-pr-comments` optionally followed by a PR URL or a comment URL.
+## Fetch Threads Workflow
+
+Retrieve unresolved review threads from GitHub.
+
+### Workflow: Fetch Unresolved Threads
+
+1. Parse the URL provided by the user:
+   - **PR URL** (`/pull/123`) — process all unresolved threads
+   - **Comment URL** (`/pull/123#discussion_r<ID>`) — process that single thread
+   - If no URL is provided, ask the user before proceeding
+2. Extract `owner`, `repo`, and `pull_number` from the URL
+3. Use `gh` CLI to fetch review threads for the PR
+4. Filter to threads where `isResolved == false`
+5. If a comment URL was given, further filter to the thread containing the comment with `databaseId == <ID>`
+6. If no unresolved threads exist, report that immediately and stop
+7. **Validation:** Threads fetched; unresolved threads identified; pagination limits noted (>100 threads or >20 comments per thread may be truncated — use comment URL to process in batches)
 
 ---
 
-## Input
+## Per-Thread Resolution Workflow
 
-The user provides either:
-- **PR URL**: `https://github.com/owner/repo/pull/123` — process all unresolved threads
-- **Comment URL**: `https://github.com/owner/repo/pull/123#discussion_r<id>` — process that single thread
+Work through each unresolved thread collaboratively.
 
-If no URL is provided, ask the user for one before proceeding.
+### Workflow: Resolve a Thread
 
-Extract `owner`, `repo`, and `pull_number` from the URL.
+For each unresolved thread, display context then work through steps 1–6:
 
----
-
-## Step 1 — Fetch threads
-
-### Single comment URL (fragment `#discussion_r<ID>`)
-
-Extract the numeric comment ID from the fragment. Use GraphQL to find the review thread that contains it:
-
-```bash
-gh api graphql -f query='
-  query {
-    repository(owner: "OWNER", name: "REPO") {
-      pullRequest(number: PR_NUM) {
-        reviewThreads(first: 100) {
-          nodes {
-            id
-            isResolved
-            path
-            diffHunk
-            comments(first: 20) {
-              nodes {
-                databaseId
-                author { login }
-                body
-                createdAt
-              }
-            }
-          }
-        }
-      }
-    }
-  }'
-```
-
-Filter to the thread whose `comments.nodes` contains a node with `databaseId == <ID>`.
-
-### PR URL (all threads)
-
-Use the same GraphQL query above. Filter to nodes where `isResolved == false`.
-
----
-
-## Step 2 — Display thread context
-
-For each thread, display clearly:
-
+**Display format:**
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Thread: <path>
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Diff hunk:
-<diffHunk>
-
 Comments:
-  [author] createdAt
-  > body
-
   [author] createdAt
   > body
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
----
+#### Step 1 — Analyze and propose
 
-## Step 3 — Per-thread loop
-
-For each unresolved thread, work through these steps in order:
-
-### 3a — Analyze and propose
-
-Claude reads the file at `path` to get current context, then proposes one of:
+Read the file at `path` to get current context, then propose one of:
 
 - **"No code change needed."** — explain what reply to send and why no change is required
 - **"Code change needed."** — describe the change; ask: *"Should I make this change?"*
 
 Wait for user confirmation or adjustment before proceeding.
 
-### 3b — Implement (if code change)
+#### Step 2 — Implement (if code change)
 
 Make the code change. **Do not commit or push yet.**
 
-### 3c — Draft commit message and reply, then confirm
+#### Step 3 — Draft commit message and reply, then confirm
 
-Compose both drafts and present them together for user approval:
+Compose both drafts and present them together for user approval.
 
-**Commit message:** follow the Nimble Compass convention (`[#ID] Verb message`). Derive the ID from the branch name using the same rules as the `/commit` skill.
+**Commit message:** Use the `/commit` skill convention (`[#ID] Verb message`). Derive the issue ID from the branch name (e.g. `chore/609-add-skill` → `#609`).
 
-**Reply:** vary the phrasing naturally based on the nature of the comment — examples:
+**Reply:** Vary the phrasing naturally based on the nature of the comment:
   - `"Good catch, fixed in <sha>."`
   - `"Good point, updated in <sha>."`
   - `"Agreed, refactored in <sha>."`
   - `"Done, updated in <sha>."`
   - `"Fixed in <sha>."`
-  - `"Updated in <sha>."`
-  - Use your judgment — pick whichever fits the tone of the original comment. Avoid repeating the same opener across multiple threads in the same PR.
-  - Use a placeholder like `<sha>` since the commit hasn't happened yet.
+  - Avoid repeating the same opener across multiple threads in the same PR.
+  - Use `<sha>` as a placeholder since the commit hasn't happened yet.
 
-For a **no-code-change** reply: brief factual explanation, 1–2 sentences max. If referencing a specific piece of code, include it as a code block with a comment on the first line showing the file path, line number, and a link to that file on GitHub:
+**No-code-change reply:** Brief factual explanation, 1–2 sentences. If referencing a specific piece of code, first use search or read to locate the snippet and determine the correct line number(s), then include it as a code block:
   ````
   ```{language inferred from file extension}
   // {path}, line {N} — https://github.com/OWNER/REPO/blob/BRANCH/path/to/file#LN
   relevant code here...
   ```
   ````
-  Use the current branch name for the link. Include only the most relevant lines — keep the snippet short.
+  Use the current branch name for the link. Keep the snippet short.
 
-No emoji unless the user adds them.
+No emoji unless the user uses them first.
 
-Show both drafts to the user at once:
+Show both drafts at once:
 
-> **Commit message:** `"[#595] Fix commit description format"`
+> **Commit message:** `"[#609] Fix wording in skill documentation"`
 > **Reply:** `"Good point, updated in <sha>."`
 > Does this look good?
 
 Wait for explicit approval (or edits) before proceeding.
 
-### 3d — Commit, push, then post the reply
+#### Step 4 — Commit and push
 
 Once the user approves:
 
-1. Commit using the approved message:
+1. Stage and commit using the `/commit` skill with the approved message
+2. Capture the short SHA: `git log --oneline -1`
+3. Push: `git push`
 
-```bash
-git add <files> && git commit -m "APPROVED COMMIT MESSAGE"
-```
+#### Step 5 — Post the reply
 
-2. Capture the short SHA:
-
-```bash
-git log --oneline -1
-```
-
-3. Push:
-
-```bash
-git push
-```
-
-4. Replace `<sha>` in the reply with the real short SHA, then post it using `in_reply_to` on the PR comments endpoint — more reliable than the `/replies` endpoint, which 404s when the target comment is itself a reply:
+Replace `<sha>` in the reply with the real short SHA, then post using `in_reply_to` (more reliable than the `/replies` endpoint, which 404s when the target comment is itself a reply):
 
 ```bash
 gh api repos/OWNER/REPO/pulls/PULL_NUMBER/comments \
@@ -165,11 +120,11 @@ gh api repos/OWNER/REPO/pulls/PULL_NUMBER/comments \
   -F in_reply_to=COMMENT_DATABASE_ID
 ```
 
-`COMMENT_DATABASE_ID` is the `databaseId` of the **first comment** in the thread (the root). `PULL_NUMBER` is the PR number extracted from the URL.
+`COMMENT_DATABASE_ID` is the `databaseId` of the **thread's top-level comment** (the oldest comment in the thread). `PULL_NUMBER` is the PR number extracted from the URL.
 
-### 3e — Mark thread resolved (conditional)
+#### Step 6 — Mark thread resolved (conditional)
 
-Only resolve the thread if the reply is conclusive — i.e. a code fix was made, or the explanation fully closes the discussion with no open questions.
+Only resolve if the reply is conclusive — a code fix was made, or the explanation fully closes the discussion with no open questions.
 
 **Do not resolve** if:
 - The reply asks a follow-up question or invites further discussion
@@ -177,8 +132,6 @@ Only resolve the thread if the reply is conclusive — i.e. a code fix was made,
 - The user's reply draft suggests the thread should stay open
 
 Ask the user: **"Should I mark this thread as resolved?"** if it's ambiguous.
-
-When resolving:
 
 ```bash
 gh api graphql -f query='
@@ -189,24 +142,16 @@ gh api graphql -f query='
   }'
 ```
 
----
-
-## Step 4 — Completion
-
-After all threads are processed, report:
-
-```
-Done — X thread(s) resolved.
-```
+**Validation:** Code change implemented (if required); commit pushed; reply posted with real SHA; thread resolved if conclusive
 
 ---
 
-## Reply conventions (Nimble Compass)
+## Reply Conventions
 
 | Situation | Reply format |
 |-----------|-------------|
-| Code changed | Vary naturally: `"Good catch, fixed in <sha>."` / `"Good point, updated in <sha>."` / `"Agreed, refactored in <sha>."` / `"Fixed in <sha>."` etc. — match the tone, don't repeat the same opener across threads |
-| No code change, explanation needed | Brief factual explanation, 1–2 sentences |
+| Code changed | Vary naturally: `"Good catch, fixed in <sha>."` / `"Good point, updated in <sha>."` / `"Agreed, refactored in <sha>."` — match the tone, avoid repeating openers |
+| No code change | Brief factual explanation, 1–2 sentences |
 | Declined / won't fix | Polite explanation of why, 1–2 sentences |
 
 - Never post a reply without user approval
@@ -215,9 +160,21 @@ Done — X thread(s) resolved.
 
 ---
 
-## Error handling
+## Error Handling
 
-- If a thread has already been resolved when you try to resolve it, skip silently and continue.
-- If `gh api` returns an error posting a reply, show the error and ask the user how to proceed — do not auto-retry.
-- If the PR has no unresolved threads, report that immediately and stop.
-- Pagination limits: `reviewThreads(first: 100)` and `comments(first: 20)` — on PRs with more than 100 review threads, or threads with more than 20 replies, results will be truncated. For PRs near these limits, process threads in batches using a comment URL instead of a PR URL.
+| Error | Action |
+|-------|--------|
+| Thread already resolved | Skip silently and continue |
+| `gh api` error posting reply | Show the error and ask the user how to proceed — do not auto-retry |
+| No unresolved threads | Report immediately and stop |
+| >100 threads or >20 comments per thread | Results may be truncated — use a comment URL to process in batches |
+
+---
+
+## Output Artifacts
+
+| When you ask for... | You get... |
+|---------------------|------------|
+| PR URL | All unresolved threads processed one at a time |
+| Comment URL | That single thread addressed |
+| Completion | `Done — X thread(s) resolved.` summary |

--- a/skills/resolve-pr-comments/SKILL.md
+++ b/skills/resolve-pr-comments/SKILL.md
@@ -224,3 +224,4 @@ Done — X thread(s) resolved.
 - If a thread has already been resolved when you try to resolve it, skip silently and continue.
 - If `gh api` returns an error posting a reply, show the error and ask the user how to proceed — do not auto-retry.
 - If the PR has no unresolved threads, report that immediately and stop.
+- Pagination limits: `reviewThreads(first: 100)` and `comments(first: 20)` — on PRs with more than 100 review threads, or threads with more than 20 replies, results will be truncated. For PRs near these limits, process threads in batches using a comment URL instead of a PR URL.

--- a/skills/resolve-pr-comments/SKILL.md
+++ b/skills/resolve-pr-comments/SKILL.md
@@ -156,11 +156,7 @@ git log --oneline -1
 git push
 ```
 
-4. Replace `<sha>` in the reply with the real short SHA, then post it:
-
-### 3e — Post the reply
-
-Use `in_reply_to` on the PR comments endpoint — more reliable than the `/replies` endpoint, which 404s when the target comment is itself a reply:
+4. Replace `<sha>` in the reply with the real short SHA, then post it using `in_reply_to` on the PR comments endpoint — more reliable than the `/replies` endpoint, which 404s when the target comment is itself a reply:
 
 ```bash
 gh api repos/OWNER/REPO/pulls/PULL_NUMBER/comments \

--- a/skills/resolve-pr-comments/SKILL.md
+++ b/skills/resolve-pr-comments/SKILL.md
@@ -120,7 +120,7 @@ gh api repos/OWNER/REPO/pulls/PULL_NUMBER/comments \
   -F in_reply_to=COMMENT_DATABASE_ID
 ```
 
-`COMMENT_DATABASE_ID` is the `databaseId` of the **thread's top-level comment** (the oldest comment in the thread). `PULL_NUMBER` is the PR number extracted from the URL.
+`COMMENT_DATABASE_ID` is the `databaseId` of the **thread's top-level comment** in the thread (oldest in the thread). `PULL_NUMBER` is the PR number extracted from the URL.
 
 #### Step 6 — Mark thread resolved (conditional)
 

--- a/skills/resolve-pr-comments/SKILL.md
+++ b/skills/resolve-pr-comments/SKILL.md
@@ -44,7 +44,7 @@ Work through each unresolved thread collaboratively.
 For each unresolved thread, display context then work through the steps below. Steps 2–5 apply only when a code change is needed; skip them otherwise.
 
 **Display format:**
-```
+```text
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Thread: <path>
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -66,7 +66,7 @@ Wait for user confirmation or adjustment before proceeding.
 **If no code change:** Draft the reply now, then skip to Step 6.
 
 Brief factual explanation, 1–2 sentences. If referencing a specific piece of code, first use search or read to locate the snippet and determine the correct line number(s), then include it as a code block:
-  ````
+  ````markdown
   ```{language inferred from file extension}
   // {path}, line {N} — https://github.com/OWNER/REPO/blob/BRANCH/path/to/file#LN
   relevant code here...


### PR DESCRIPTION
- Close #609

## What happened 👀

Adds the `/resolve-pr-comments` skill to the `skills/` folder. The skill guides Claude Code through resolving GitHub PR review threads one at a time, collaboratively with the developer:

- Fetches unresolved review threads via GitHub GraphQL API
- Displays each thread with its diff hunk and comments
- Analyzes the feedback and proposes a code change or a no-code explanation
- Drafts a commit message and reply for user approval before acting
- Commits, pushes, posts the reply (via `in_reply_to`), and optionally resolves the thread

## Insight 📝

The skill follows the same structure as the existing `/commit` skill — a single `SKILL.md` under `skills/resolve-pr-comments/`. It uses `gh api graphql` to fetch review threads (more reliable than REST for thread metadata) and posts replies using the `in_reply_to` parameter on the PR comments endpoint, which avoids 404s that occur when targeting nested reply comments directly via the `/replies` endpoint.

To test: invoke `/resolve-pr-comments <PR URL>` on any PR with open review threads and walk through the prompted workflow.

## Proof Of Work 📹

<img width="521" height="1047" alt="CleanShot 2026-03-24 at 10 11 12" src="https://github.com/user-attachments/assets/1eec4a7b-4e41-40fa-a2d0-36a3188c3d5f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a user-facing specification and guided workflow for a new /resolve-pr-comments command to handle GitHub PR review threads one at a time. Covers accepted input formats, fetching and filtering unresolved threads, per-thread context display, guided decision steps (no-change vs code-change), branch/commit guidance, drafting and posting replies, conditional thread resolution, error-handling rules, truncation/limits, and a completion summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->