### PR TITLE
[#369] Use fastlane for match in Bitrise workflow

### DIFF
--- a/.cicdtemplate/.bitrise/bitrise.yml
+++ b/.cicdtemplate/.bitrise/bitrise.yml
@@ -207,10 +207,6 @@ workflows:
         inputs:
         - scheme: $BITRISE_SCHEME
     - fastlane@3:
-        title: Sync Development Staging code signing
-        inputs:
-        - lane: syncDevelopmentStagingCodeSigning
-    - fastlane@3:
         title: Sync Ad Hoc Staging code signing
         inputs:
         - lane: syncAdHocStagingCodeSigning

--- a/.cicdtemplate/.bitrise/bitrise.yml
+++ b/.cicdtemplate/.bitrise/bitrise.yml
@@ -1,5 +1,13 @@
 ---
-format_version: '11'
+# SECRETS needed:
+### SSH_RSA_PRIVATE_KEY
+### MATCH_PASSWORD
+### API_KEY_ID
+### ISSUER_ID
+### APPSTORE_CONNECT_API_KEY
+### FIREBASE_TOKEN
+
+format_version: '26'
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 project_type: ios
 tools:
@@ -7,9 +15,9 @@ tools:
 trigger_map:
 - push_branch: develop
   workflow: deploy_staging
-- push_branch: master
-  workflow: deploy_app_store
 - push_branch: main
+  workflow: deploy_testflight
+- push_branch: master
   workflow: deploy_app_store
 - push_branch: release
   workflow: deploy_release_firebase
@@ -29,29 +37,92 @@ workflows:
             echo "Gem cache directory: $RBENV_DIR"
             envman add --key GEM_CACHE_PATH --value $RBENV_DIR
         title: Set GEM_CACHE_PATH env var
-    - git-clone@6.1: {}
-    - cache-pull@2: {}
-    - xcode-test@4.0: {}
-    - fastlane-match@0:
+    - git-clone@8: {}
+    - restore-cache@3:
         inputs:
-        - type: appstore
-        - team_id: "$TEAM_ID"
-        - decrypt_password: "$MATCH_PASSWORD"
-        - git_url: "$MATCH_REPO_URL"
-        - app_id: "$BUNDLE_ID"
+        - key: |-
+            spm-project-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
+            spm-project-{{ checksum "Gemfile.lock" }}
+            spm-project-
+    - xcode-test@6:
+        inputs:
+        - scheme: $BITRISE_SCHEME
+    - fastlane@3:
+        title: Sync App Store code signing
+        inputs:
+        - lane: syncAppStoreCodeSigning
     - fastlane@3:
         title: Build and upload Production app to App Store
         inputs:
-        - lane: buildAndUploadToAppStoreLane
-    - deploy-to-bitrise-io:
+        - lane: buildAndUploadToAppStore
+    - fastlane@3:
+        title: Remove CI keychain
         inputs:
-        - deploy_path: $BUILD_PATH
+        - lane: removeKeychain
+    - deploy-to-bitrise-io@2:
+        inputs:
+        - deploy_path: "$BUILD_PATH"
         is_always_run: false
-    - cache-push@2:
+    - save-cache@1:
         inputs:
-        - cache_paths: |-
+        - key: spm-project-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
+        - paths: |-
             $BITRISE_CACHE_DIR
             $GEM_CACHE_PATH
+            ~/Library/Developer/Xcode/DerivedData
+    envs:
+    - opts:
+        is_expand: false
+      BUNDLE_ID: {BUNDLE_ID_PRODUCTION}
+    - opts:
+        is_expand: false
+      BITRISE_SCHEME: {PROJECT_NAME}
+  deploy_testflight:
+    steps:
+    - activate-ssh-key@4:
+        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+    - script@1:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -ex
+            RBENV_DIR="`cd $(rbenv which ruby)/../..;pwd`"
+            echo "Gem cache directory: $RBENV_DIR"
+            envman add --key GEM_CACHE_PATH --value $RBENV_DIR
+        title: Set GEM_CACHE_PATH env var
+    - git-clone@8: {}
+    - restore-cache@3:
+        inputs:
+        - key: |-
+            spm-project-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
+            spm-project-{{ checksum "Gemfile.lock" }}
+            spm-project-
+    - xcode-test@6:
+        inputs:
+        - scheme: $BITRISE_SCHEME
+    - fastlane@3:
+        title: Sync App Store code signing
+        inputs:
+        - lane: syncAppStoreCodeSigning
+    - fastlane@3:
+        title: Build and upload Production app to TestFlight
+        inputs:
+        - lane: buildAndUploadToTestFlight
+    - fastlane@3:
+        title: Remove CI keychain
+        inputs:
+        - lane: removeKeychain
+    - deploy-to-bitrise-io@2:
+        inputs:
+        - deploy_path: "$BUILD_PATH"
+        is_always_run: false
+    - save-cache@1:
+        inputs:
+        - key: spm-project-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
+        - paths: |-
+            $BITRISE_CACHE_DIR
+            $GEM_CACHE_PATH
+            ~/Library/Developer/Xcode/DerivedData
     envs:
     - opts:
         is_expand: false
@@ -72,29 +143,39 @@ workflows:
             echo "Gem cache directory: $RBENV_DIR"
             envman add --key GEM_CACHE_PATH --value $RBENV_DIR
         title: Set GEM_CACHE_PATH env var
-    - git-clone@6.1: {}
-    - cache-pull@2: {}
-    - xcode-test@4.0: {}
-    - fastlane-match@0:
+    - git-clone@8: {}
+    - restore-cache@3:
         inputs:
-        - type: appstore
-        - team_id: "$TEAM_ID"
-        - app_id: "$BUNDLE_ID"
-        - git_url: "$MATCH_REPO_URL"
-        - decrypt_password: "$MATCH_PASSWORD"
+        - key: |-
+            spm-project-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
+            spm-project-{{ checksum "Gemfile.lock" }}
+            spm-project-
+    - xcode-test@6:
+        inputs:
+        - scheme: $BITRISE_SCHEME
+    - fastlane@3:
+        title: Sync Ad Hoc Production code signing
+        inputs:
+        - lane: syncAdHocProductionCodeSigning
     - fastlane@3:
         title: Build and Upload Production App
         inputs:
-        - lane: buildProductionAndUploadToFirebaseLane
-    - deploy-to-bitrise-io:
+        - lane: buildProductionAndUploadToFirebase
+    - fastlane@3:
+        title: Remove CI keychain
         inputs:
-        - deploy_path: $BUILD_PATH
+        - lane: removeKeychain
+    - deploy-to-bitrise-io@2:
+        inputs:
+        - deploy_path: "$BUILD_PATH"
         is_always_run: false
-    - cache-push@2:
+    - save-cache@1:
         inputs:
-        - cache_paths: |-
+        - key: spm-project-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
+        - paths: |-
             $BITRISE_CACHE_DIR
             $GEM_CACHE_PATH
+            ~/Library/Developer/Xcode/DerivedData
     envs:
     - opts:
         is_expand: false
@@ -115,29 +196,43 @@ workflows:
             echo "Gem cache directory: $RBENV_DIR"
             envman add --key GEM_CACHE_PATH --value $RBENV_DIR
         title: Set GEM_CACHE_PATH env var
-    - git-clone@6.1: {}
-    - cache-pull@2: {}
-    - xcode-test@4.0: {}
-    - fastlane-match@0:
+    - git-clone@8: {}
+    - restore-cache@3:
         inputs:
-        - type: adhoc
-        - team_id: "$TEAM_ID"
-        - app_id: "$BUNDLE_ID"
-        - git_url: "$MATCH_REPO_URL"
-        - decrypt_password: "$MATCH_PASSWORD"
+        - key: |-
+            spm-project-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
+            spm-project-{{ checksum "Gemfile.lock" }}
+            spm-project-
+    - xcode-test@6:
+        inputs:
+        - scheme: $BITRISE_SCHEME
+    - fastlane@3:
+        title: Sync Development Staging code signing
+        inputs:
+        - lane: syncDevelopmentStagingCodeSigning
+    - fastlane@3:
+        title: Sync Ad Hoc Staging code signing
+        inputs:
+        - lane: syncAdHocStagingCodeSigning
     - fastlane@3:
         title: Build and Upload Staging App
         inputs:
-        - lane: buildStagingAndUploadToFirebaseLane
-    - deploy-to-bitrise-io:
+        - lane: buildStagingAndUploadToFirebase
+    - fastlane@3:
+        title: Remove CI keychain
         inputs:
-        - deploy_path: $BUILD_PATH
+        - lane: removeKeychain
+    - deploy-to-bitrise-io@2:
+        inputs:
+        - deploy_path: "$BUILD_PATH"
         is_always_run: false
-    - cache-push@2:
+    - save-cache@1:
         inputs:
-        - cache_paths: |-
+        - key: spm-project-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
+        - paths: |-
             $BITRISE_CACHE_DIR
             $GEM_CACHE_PATH
+            ~/Library/Developer/Xcode/DerivedData
     envs:
     - opts:
         is_expand: false
@@ -158,22 +253,29 @@ workflows:
             echo "Gem cache directory: $RBENV_DIR"
             envman add --key GEM_CACHE_PATH --value $RBENV_DIR
         title: Set GEM_CACHE_PATH env var
-    - git-clone@6.1: {}
-    - cache-pull@2: {}
+    - git-clone@8: {}
+    - restore-cache@3:
+        inputs:
+        - key: |-
+            spm-project-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
+            spm-project-{{ checksum "Gemfile.lock" }}
+            spm-project-
     - fastlane@3:
         inputs:
-        - lane: buildAndTestLane
+        - lane: buildAndTest
     - fastlane@3:
         inputs:
-        - lane: cleanUpOutputLane
+        - lane: cleanUpOutput
     - danger@2:
         inputs:
         - github_api_token: "$DANGER_GITHUB_API_TOKEN"
-    - cache-push@2:
+    - save-cache@1:
         inputs:
-        - cache_paths: |-
+        - key: spm-project-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
+        - paths: |-
             $BITRISE_CACHE_DIR
             $GEM_CACHE_PATH
+            ~/Library/Developer/Xcode/DerivedData
     envs:
     - opts:
         is_expand: false

--- a/.cicdtemplate/.bitrise/bitrise.yml
+++ b/.cicdtemplate/.bitrise/bitrise.yml
@@ -6,6 +6,7 @@
 ### ISSUER_ID
 ### APPSTORE_CONNECT_API_KEY
 ### FIREBASE_TOKEN
+### DANGER_GITHUB_API_TOKEN
 
 format_version: '26'
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
@@ -41,9 +42,9 @@ workflows:
     - restore-cache@3:
         inputs:
         - key: |-
-            spm-project-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
-            spm-project-{{ checksum "Gemfile.lock" }}
-            spm-project-
+            spm-project-{{ getenv "BITRISE_SCHEME" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
+            spm-project-{{ getenv "BITRISE_SCHEME" }}-{{ checksum "Gemfile.lock" }}
+            spm-project-{{ getenv "BITRISE_SCHEME" }}-
     - xcode-test@6:
         inputs:
         - scheme: $BITRISE_SCHEME
@@ -59,13 +60,14 @@ workflows:
         title: Remove CI keychain
         inputs:
         - lane: removeKeychain
+        is_always_run: true
     - deploy-to-bitrise-io@2:
         inputs:
         - deploy_path: "$BUILD_PATH"
         is_always_run: false
     - save-cache@1:
         inputs:
-        - key: spm-project-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
+        - key: spm-project-{{ getenv "BITRISE_SCHEME" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
         - paths: |-
             $BITRISE_CACHE_DIR
             $GEM_CACHE_PATH
@@ -94,9 +96,9 @@ workflows:
     - restore-cache@3:
         inputs:
         - key: |-
-            spm-project-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
-            spm-project-{{ checksum "Gemfile.lock" }}
-            spm-project-
+            spm-project-{{ getenv "BITRISE_SCHEME" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
+            spm-project-{{ getenv "BITRISE_SCHEME" }}-{{ checksum "Gemfile.lock" }}
+            spm-project-{{ getenv "BITRISE_SCHEME" }}-
     - xcode-test@6:
         inputs:
         - scheme: $BITRISE_SCHEME
@@ -112,13 +114,14 @@ workflows:
         title: Remove CI keychain
         inputs:
         - lane: removeKeychain
+        is_always_run: true
     - deploy-to-bitrise-io@2:
         inputs:
         - deploy_path: "$BUILD_PATH"
         is_always_run: false
     - save-cache@1:
         inputs:
-        - key: spm-project-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
+        - key: spm-project-{{ getenv "BITRISE_SCHEME" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
         - paths: |-
             $BITRISE_CACHE_DIR
             $GEM_CACHE_PATH
@@ -147,9 +150,9 @@ workflows:
     - restore-cache@3:
         inputs:
         - key: |-
-            spm-project-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
-            spm-project-{{ checksum "Gemfile.lock" }}
-            spm-project-
+            spm-project-{{ getenv "BITRISE_SCHEME" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
+            spm-project-{{ getenv "BITRISE_SCHEME" }}-{{ checksum "Gemfile.lock" }}
+            spm-project-{{ getenv "BITRISE_SCHEME" }}-
     - xcode-test@6:
         inputs:
         - scheme: $BITRISE_SCHEME
@@ -165,13 +168,14 @@ workflows:
         title: Remove CI keychain
         inputs:
         - lane: removeKeychain
+        is_always_run: true
     - deploy-to-bitrise-io@2:
         inputs:
         - deploy_path: "$BUILD_PATH"
         is_always_run: false
     - save-cache@1:
         inputs:
-        - key: spm-project-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
+        - key: spm-project-{{ getenv "BITRISE_SCHEME" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
         - paths: |-
             $BITRISE_CACHE_DIR
             $GEM_CACHE_PATH
@@ -200,9 +204,9 @@ workflows:
     - restore-cache@3:
         inputs:
         - key: |-
-            spm-project-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
-            spm-project-{{ checksum "Gemfile.lock" }}
-            spm-project-
+            spm-project-{{ getenv "BITRISE_SCHEME" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
+            spm-project-{{ getenv "BITRISE_SCHEME" }}-{{ checksum "Gemfile.lock" }}
+            spm-project-{{ getenv "BITRISE_SCHEME" }}-
     - xcode-test@6:
         inputs:
         - scheme: $BITRISE_SCHEME
@@ -218,13 +222,14 @@ workflows:
         title: Remove CI keychain
         inputs:
         - lane: removeKeychain
+        is_always_run: true
     - deploy-to-bitrise-io@2:
         inputs:
         - deploy_path: "$BUILD_PATH"
         is_always_run: false
     - save-cache@1:
         inputs:
-        - key: spm-project-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
+        - key: spm-project-{{ getenv "BITRISE_SCHEME" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
         - paths: |-
             $BITRISE_CACHE_DIR
             $GEM_CACHE_PATH
@@ -253,9 +258,9 @@ workflows:
     - restore-cache@3:
         inputs:
         - key: |-
-            spm-project-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
-            spm-project-{{ checksum "Gemfile.lock" }}
-            spm-project-
+            spm-project-{{ getenv "BITRISE_SCHEME" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
+            spm-project-{{ getenv "BITRISE_SCHEME" }}-{{ checksum "Gemfile.lock" }}
+            spm-project-{{ getenv "BITRISE_SCHEME" }}-
     - fastlane@3:
         inputs:
         - lane: buildAndTest
@@ -267,7 +272,7 @@ workflows:
         - github_api_token: "$DANGER_GITHUB_API_TOKEN"
     - save-cache@1:
         inputs:
-        - key: spm-project-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
+        - key: spm-project-{{ getenv "BITRISE_SCHEME" }}-{{ checksum "Gemfile.lock" }}-{{ checksum "**/Package.resolved" }}
         - paths: |-
             $BITRISE_CACHE_DIR
             $GEM_CACHE_PATH

--- a/.cicdtemplate/.bitrise/bitrise.yml
+++ b/.cicdtemplate/.bitrise/bitrise.yml
@@ -18,8 +18,6 @@ trigger_map:
   workflow: deploy_staging
 - push_branch: main
   workflow: deploy_testflight
-- push_branch: master
-  workflow: deploy_app_store
 - push_branch: release
   workflow: deploy_release_firebase
 - push_branch: "*"
@@ -80,6 +78,8 @@ workflows:
         is_expand: false
       BITRISE_SCHEME: {PROJECT_NAME}
   deploy_testflight:
+    after_run:
+    - deploy_app_store
     steps:
     - activate-ssh-key@4:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'


### PR DESCRIPTION
- Close #369 

## What happened 👀

- Use our defined fastlane lanes: `syncAdHocProductionCodeSigning`, `syncAppStoreCodeSigning` instead of Bitrise fastlane match to match code signing.
- Introduce new workflow `deploy_testflight` on push to `main` branch.
- Update `restose cache` step:
    - `cache-pull` -> `restore-cache`
    - `cashe-push `-> `save-cache`
- Add step remove key chain, use `removeKeyChainLane` at the end of all workflows.
- Update step to the latest major version.
- Add a comment for secrets needed to run the workflow.
- Remove `-Lane` suffix on all lanes.

## Insight 📝

TBD

## Proof Of Work 📹
The POW was collected from my side project, which utilizes the same Fastlane lanes as our template.

- **deploy-staging workflow**

<img width="1571" height="826" alt="deploy-staging" src="https://github.com/user-attachments/assets/8a922f6e-6c48-4cf5-8da4-d886cbb0a9ba" />

<img width="1380" height="1101" alt="firebase-distribution" src="https://github.com/user-attachments/assets/b033ea21-eee8-4ba4-af8c-b721ac2f4d45" />


- **deploy-testflight workflow**

<img width="1571" height="890" alt="deploy-testflight" src="https://github.com/user-attachments/assets/88b5c050-a887-4b74-95ef-0db42ffeb24a" />

<img width="1451" height="933" alt="appstoreconnect" src="https://github.com/user-attachments/assets/6a446f6c-0df8-4b44-9037-645c6914bfd5" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded CI/CD configuration and build steps for improved stability and faster builds.
  * Expanded and standardized caching (explicit cache keys, preserved DerivedData) for quicker incremental builds.
  * Reworked signing and keychain handling for more reliable, secure releases; keychain removal now always runs.
  * Updated deployment workflows and step versions across staging, Firebase, and App Store flows.
* **New Features**
  * Added a dedicated TestFlight deployment workflow triggered from the primary branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->