### PR TITLE
[#627] Add a workflow to draft a release

### DIFF
--- a/.github/workflows/draft_a_new_release.yml
+++ b/.github/workflows/draft_a_new_release.yml
@@ -1,0 +1,18 @@
+name: Draft a new release
+
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Add `.github/workflows/draft_a_new_release.yml` — a GitHub Actions workflow that uses `release-drafter/release-drafter@v5` to automatically draft a release whenever a push lands on `main`.

## Why

Closes #627 — the iOS template was missing this workflow that already exists in the sample app.