### PR TITLE
[#627] Add a workflow to draft a release

### DIFF
--- a/.github/workflows/draft_a_new_release.yml
+++ b/.github/workflows/draft_a_new_release.yml
@@ -1,0 +1,18 @@
+name: Draft a new release
+
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/draft_a_new_release.yml
+++ b/.github/workflows/draft_a_new_release.yml
@@ -13,6 +13,6 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Close #627

## What happened 👀

Add `.github/workflows/draft_a_new_release.yml` — a GitHub Actions workflow that uses `release-drafter/release-drafter@v5` to automatically draft a release whenever a push lands on `main`. The `release-drafter.yml` config already exists in the repo, so no additional config is needed.

## Insight 📝

The iOS template was the only template missing this workflow. The workflow is copied from the sample app which already has it in place. The `release-drafter` action reads `.github/release-drafter.yml` (already present) to categorize PRs by label and generate release notes automatically.

## Proof Of Work 📹

N/A 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated release draft generation to streamline the release management process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->