### PR TITLE
[#642] Add reusable setup composite action for CI enviroment

### DIFF
--- a/.cicdtemplate/.github/actions/setup-ci-environment/action.yml
+++ b/.cicdtemplate/.github/actions/setup-ci-environment/action.yml
@@ -1,0 +1,47 @@
+name: Setup CI Environment
+description: Prepare Ruby, mise tools, and Bundler dependencies for CI jobs.
+
+inputs:
+  ruby-version:
+    description: Ruby version to install.
+    required: false
+    default: "3.2"
+  setup-mise:
+    description: Whether to install tools from .mise.toml.
+    required: false
+    default: "true"
+  bundler-cache:
+    description: Whether to enable Bundler cache via ruby/setup-ruby.
+    required: false
+    default: "true"
+  working-directory:
+    description: Directory where bundle install should run.
+    required: false
+    default: "."
+  run-bundle-install:
+    description: Whether to run bundle install.
+    required: false
+    default: "true"
+  bundle-install-command:
+    description: Bundle install command to run when enabled.
+    required: false
+    default: "bundle install"
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ inputs.ruby-version }}
+        bundler-cache: ${{ inputs.bundler-cache }}
+
+    - name: Install tools with mise
+      if: ${{ inputs.setup-mise == 'true' }}
+      uses: jdx/mise-action@v4.0.1
+
+    - name: Bundle install
+      if: ${{ inputs.run-bundle-install == 'true' && inputs.bundler-cache != 'true' }}
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: ${{ inputs.bundle-install-command }}

--- a/.cicdtemplate/.github/workflows/add_device_profile.yml
+++ b/.cicdtemplate/.github/workflows/add_device_profile.yml
@@ -39,11 +39,8 @@ jobs:
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-    - name: Install tools with mise
-      uses: jdx/mise-action@v4.0.1
-
-    - name: Bundle install
-      run: bundle install
+    - name: Setup CI environment
+      uses: ./.github/actions/setup-ci-environment
 
     - name: Add device and regenerate profiles with match
       run: bundle exec fastlane addDevicesGenerateProfiles

--- a/.cicdtemplate/.github/workflows/automatic_pull_request_review.yml
+++ b/.cicdtemplate/.github/workflows/automatic_pull_request_review.yml
@@ -25,8 +25,11 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gems-
 
-    - name: Install tools with mise
-      uses: jdx/mise-action@v4.0.1
+    - name: Setup CI environment
+      uses: ./.github/actions/setup-ci-environment
+      with:
+        bundler-cache: "false"
+        bundle-install-command: "bundle install --path vendor/bundle"
 
     - name: Setup ENV file
       env:
@@ -35,9 +38,6 @@ jobs:
         touch .env
         echo $ENV | base64 --decode > .env
 
-    - name: Bundle install
-      run: bundle install --path vendor/bundle
-      
     - name: Run Arkana
       run: bundle exec arkana
 

--- a/.cicdtemplate/.github/workflows/deploy_app_store.yml
+++ b/.cicdtemplate/.github/workflows/deploy_app_store.yml
@@ -53,11 +53,8 @@ jobs:
         touch .env
         echo $ENV | base64 --decode > .env
 
-    - name: Install tools with mise
-      uses: jdx/mise-action@v4.0.1
-
-    - name: Bundle install
-      run: bundle install
+    - name: Setup CI environment
+      uses: ./.github/actions/setup-ci-environment
       
     - name: Run Arkana
       run: bundle exec arkana

--- a/.cicdtemplate/.github/workflows/deploy_dev_firebase.yml
+++ b/.cicdtemplate/.github/workflows/deploy_dev_firebase.yml
@@ -66,8 +66,8 @@ jobs:
         fileName: 'firebase_service_account.json'
         encodedString: ${{ secrets.FIREBASE_GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
 
-    - name: Bundle install
-      run: bundle install
+    - name: Setup CI environment
+      uses: ./.github/actions/setup-ci-environment
       
     - name: Run Arkana
       run: bundle exec arkana

--- a/.cicdtemplate/.github/workflows/deploy_production_firebase.yml
+++ b/.cicdtemplate/.github/workflows/deploy_production_firebase.yml
@@ -62,11 +62,8 @@ jobs:
         fileName: 'firebase_service_account.json'
         encodedString: ${{ secrets.FIREBASE_GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
 
-    - name: Install tools with mise
-      uses: jdx/mise-action@v4.0.1
-
-    - name: Bundle install
-      run: bundle install
+    - name: Setup CI environment
+      uses: ./.github/actions/setup-ci-environment
       
     - name: Run Arkana
       run: bundle exec arkana

--- a/.cicdtemplate/.github/workflows/deploy_staging_firebase.yml
+++ b/.cicdtemplate/.github/workflows/deploy_staging_firebase.yml
@@ -67,11 +67,8 @@ jobs:
         fileName: 'firebase_service_account.json'
         encodedString: ${{ secrets.FIREBASE_GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
 
-    - name: Install tools with mise
-      uses: jdx/mise-action@v4.0.1
-
-    - name: Bundle install
-      run: bundle install
+    - name: Setup CI environment
+      uses: ./.github/actions/setup-ci-environment
       
     - name: Run Arkana
       run: bundle exec arkana

--- a/.github/actions/setup-ci-environment/action.yml
+++ b/.github/actions/setup-ci-environment/action.yml
@@ -1,0 +1,47 @@
+name: Setup CI Environment
+description: Prepare Ruby, mise tools, and Bundler dependencies for CI jobs.
+
+inputs:
+  ruby-version:
+    description: Ruby version to install.
+    required: false
+    default: "3.2"
+  setup-mise:
+    description: Whether to install tools from .mise.toml.
+    required: false
+    default: "true"
+  bundler-cache:
+    description: Whether to enable Bundler cache via ruby/setup-ruby.
+    required: false
+    default: "true"
+  working-directory:
+    description: Directory where bundle install should run.
+    required: false
+    default: "."
+  run-bundle-install:
+    description: Whether to run bundle install.
+    required: false
+    default: "true"
+  bundle-install-command:
+    description: Bundle install command to run when enabled.
+    required: false
+    default: "bundle install"
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ inputs.ruby-version }}
+        bundler-cache: ${{ inputs.bundler-cache }}
+
+    - name: Install tools with mise
+      if: ${{ inputs.setup-mise == 'true' }}
+      uses: jdx/mise-action@v4.0.1
+
+    - name: Bundle install
+      if: ${{ inputs.run-bundle-install == 'true' && inputs.bundler-cache != 'true' }}
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: ${{ inputs.bundle-install-command }}

--- a/.github/workflows/test_upload_build_staging_to_firebase.yml
+++ b/.github/workflows/test_upload_build_staging_to_firebase.yml
@@ -68,8 +68,8 @@ jobs:
         fileName: "firebase_service_account.json"
         encodedString: ${{ secrets.FIREBASE_GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
 
-    - name: Install tools with mise
-      uses: jdx/mise-action@v4.0.1
+    - name: Setup CI environment
+      uses: ./.github/actions/setup-ci-environment
 
     - name: Configure Template App for Firebase upload
       run: swift run --package-path scripts/iOSTemplateMaker iOSTemplateMaker make-test-firebase

--- a/.github/workflows/test_upload_build_to_test_flight.yml
+++ b/.github/workflows/test_upload_build_to_test_flight.yml
@@ -30,16 +30,13 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install tools with mise
-      uses: jdx/mise-action@v4.0.1
-
     - name: Install SSH key
       uses: webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-    - name: Bundle install
-      run: bundle install
+    - name: Setup CI environment
+      uses: ./.github/actions/setup-ci-environment
 
     - name: Cache SPM Packages
       uses: actions/cache@v4

--- a/.github/workflows/test_upload_dev_build_to_firebase.yml
+++ b/.github/workflows/test_upload_dev_build_to_firebase.yml
@@ -53,8 +53,8 @@ jobs:
         fileName: 'firebase_service_account.json'
         encodedString: ${{ secrets.FIREBASE_GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
 
-    - name: Install tools with mise
-      uses: jdx/mise-action@v4.0.1
+    - name: Setup CI environment
+      uses: ./.github/actions/setup-ci-environment
 
     - name: Configure Template App for Firebase upload
       run: swift run --package-path scripts/iOSTemplateMaker iOSTemplateMaker make-test-firebase

--- a/.github/workflows/verify_newproject_script.yml
+++ b/.github/workflows/verify_newproject_script.yml
@@ -20,8 +20,11 @@ jobs:
     - name: Copy mise config
       run: cp template/.mise.toml .mise.toml
 
-    - name: Install tools with mise
-      uses: jdx/mise-action@v4.0.1
+    - name: Setup CI environment
+      uses: ./.github/actions/setup-ci-environment
+      with:
+        bundler-cache: "false"
+        run-bundle-install: "false"
 
     - name: Run iOSTemplateMaker
       run: |

--- a/sample/.github/actions/setup-ci-environment/action.yml
+++ b/sample/.github/actions/setup-ci-environment/action.yml
@@ -1,0 +1,47 @@
+name: Setup CI Environment
+description: Prepare Ruby, mise tools, and Bundler dependencies for CI jobs.
+
+inputs:
+  ruby-version:
+    description: Ruby version to install.
+    required: false
+    default: "3.2"
+  setup-mise:
+    description: Whether to install tools from .mise.toml.
+    required: false
+    default: "true"
+  bundler-cache:
+    description: Whether to enable Bundler cache via ruby/setup-ruby.
+    required: false
+    default: "true"
+  working-directory:
+    description: Directory where bundle install should run.
+    required: false
+    default: "."
+  run-bundle-install:
+    description: Whether to run bundle install.
+    required: false
+    default: "true"
+  bundle-install-command:
+    description: Bundle install command to run when enabled.
+    required: false
+    default: "bundle install"
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ inputs.ruby-version }}
+        bundler-cache: ${{ inputs.bundler-cache }}
+
+    - name: Install tools with mise
+      if: ${{ inputs.setup-mise == 'true' }}
+      uses: jdx/mise-action@v4.0.1
+
+    - name: Bundle install
+      if: ${{ inputs.run-bundle-install == 'true' && inputs.bundler-cache != 'true' }}
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: ${{ inputs.bundle-install-command }}

--- a/sample/.github/workflows/add_device_profile.yml
+++ b/sample/.github/workflows/add_device_profile.yml
@@ -39,8 +39,8 @@ jobs:
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-    - name: Bundle install
-      run: bundle install
+    - name: Setup CI environment
+      uses: ./.github/actions/setup-ci-environment
 
     - name: Add device and regenerate profiles with match
       run: bundle exec fastlane addDevicesGenerateProfiles

--- a/sample/.github/workflows/automatic_pull_request_review.yml
+++ b/sample/.github/workflows/automatic_pull_request_review.yml
@@ -32,8 +32,11 @@ jobs:
         touch .env
         echo $ENV | base64 --decode > .env
 
-    - name: Bundle install
-      run: bundle install --path vendor/bundle
+    - name: Setup CI environment
+      uses: ./.github/actions/setup-ci-environment
+      with:
+        bundler-cache: "false"
+        bundle-install-command: "bundle install --path vendor/bundle"
       
     - name: Run Arkana
       run: bundle exec arkana

--- a/sample/.github/workflows/deploy_app_store.yml
+++ b/sample/.github/workflows/deploy_app_store.yml
@@ -53,8 +53,8 @@ jobs:
         touch .env
         echo $ENV | base64 --decode > .env
 
-    - name: Bundle install
-      run: bundle install
+    - name: Setup CI environment
+      uses: ./.github/actions/setup-ci-environment
       
     - name: Run Arkana
       run: bundle exec arkana

--- a/sample/.github/workflows/deploy_production_firebase.yml
+++ b/sample/.github/workflows/deploy_production_firebase.yml
@@ -63,8 +63,8 @@ jobs:
         fileName: 'firebase_service_account.json'
         encodedString: ${{ secrets.FIREBASE_GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
 
-    - name: Bundle install
-      run: bundle install
+    - name: Setup CI environment
+      uses: ./.github/actions/setup-ci-environment
       
     - name: Run Arkana
       run: bundle exec arkana

--- a/sample/.github/workflows/deploy_staging_firebase.yml
+++ b/sample/.github/workflows/deploy_staging_firebase.yml
@@ -68,11 +68,8 @@ jobs:
         fileName: 'firebase_service_account.json'
         encodedString: ${{ secrets.FIREBASE_GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
 
-    - name: Install tools with mise
-      uses: jdx/mise-action@v4.0.1
-
-    - name: Bundle install
-      run: bundle install
+    - name: Setup CI environment
+      uses: ./.github/actions/setup-ci-environment
 
     - name: Run Arkana
       run: bundle exec arkana


### PR DESCRIPTION
- Close #642 

## What happened 👀

- Added reusable action:
    - .github/actions/setup-ci-environment/action.yml
    - .cicdtemplate/.github/actions/setup-ci-environment/action.yml
    - sample/.github/actions/setup-ci-environment/action.yml
 - Replaced duplicated mise + bundle install steps with: `uses: ./.github/actions/setup-ci-environment`
 - Reapplied usage in all targeted workflows:
    - Root: test_upload_build_to_test_flight, test_upload_dev_build_to_firebase, test_upload_build_staging_to_firebase, verify_newproject_script
    - .cicdtemplate: deploy_app_store, deploy_staging_firebase, deploy_production_firebase, deploy_dev_firebase, add_device_profile, automatic_pull_request_review
    - sample: deploy_staging_firebase, deploy_app_store, deploy_production_firebase, add_device_profile, automatic_pull_request_review

## Insight 📝

- `setup-ci-environment` now supports:
  - Ruby setup (ruby/setup-ruby)
  - Optional Bundler cache (bundler-cache, default true)
  - Optional mise install (setup-mise, default true)
  - Optional bundle install (run-bundle-install)
  - Custom bundle command (bundle-install-command)

## Proof Of Work 📹

- `deploy_dev_firebase`
<img width="1845" height="360" alt="Screenshot 2026-04-06 at 10 26 45" src="https://github.com/user-attachments/assets/4421f891-374d-4ede-bc6f-fe56e8796a50" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized CI environment setup across build workflows to improve consistency and reduce duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->