### PR TITLE
[#644]  Fix: Include DomainTests and DataTests in the default app schemes

### DIFF
--- a/sample/Modules/Data/Tests/Sources/Dummies/DummyRequestConfiguration.swift
+++ b/sample/Modules/Data/Tests/Sources/Dummies/DummyRequestConfiguration.swift
@@ -20,8 +20,8 @@ struct DummyRequestConfiguration: RequestConfiguration {
 
 extension DummyRequestConfiguration: RequestConfigurationStubable {
 
-    var sampleData: Data {
-        DummyNetworkModel.json.data(using: .utf8) ?? Data()
+    var sampleData: Foundation.Data {
+        DummyNetworkModel.json.data(using: .utf8) ?? Foundation.Data()
     }
 
     var path: String {

--- a/sample/Modules/Data/Tests/Sources/Specs/NetworkAPI/NetworkAPISpec.swift
+++ b/sample/Modules/Data/Tests/Sources/Specs/NetworkAPI/NetworkAPISpec.swift
@@ -2,6 +2,7 @@
 //  NetworkAPISpec.swift
 //
 
+import Foundation
 import Nimble
 import Quick
 
@@ -30,7 +31,7 @@ final class NetworkAPISpec: AsyncSpec {
                 context("when network returns value") {
 
                     beforeEach {
-                        NetworkStubber.stub(requestConfiguration)
+                        NetworkStubber.addStub(requestConfiguration)
                         networkAPI = NetworkAPI()
                     }
 
@@ -46,7 +47,7 @@ final class NetworkAPISpec: AsyncSpec {
                 context("when network returns error") {
 
                     beforeEach {
-                        NetworkStubber.stub(requestConfiguration, data: Data(), statusCode: 400)
+                        NetworkStubber.addStub(requestConfiguration, data: Foundation.Data(), statusCode: 400)
                         networkAPI = NetworkAPI()
                     }
 

--- a/sample/Modules/Data/Tests/Sources/Utilities/NetworkStubber.swift
+++ b/sample/Modules/Data/Tests/Sources/Utilities/NetworkStubber.swift
@@ -2,11 +2,13 @@
 //  NetworkStubber.swift
 //
 
+import Foundation
 import OHHTTPStubs
+import OHHTTPStubsSwift
 
 protocol RequestConfigurationStubable {
 
-    var sampleData: Data { get }
+    var sampleData: Foundation.Data { get }
     var path: String { get }
 }
 
@@ -16,12 +18,12 @@ enum NetworkStubber {
         HTTPStubs.removeAllStubs()
     }
 
-    static func stub(
+    static func addStub(
         _ request: RequestConfigurationStubable,
-        data: Data? = nil,
+        data: Foundation.Data? = nil,
         statusCode: Int32 = 200
     ) {
-        OHHTTPStubs.stub(condition: isPath(request.path)) { _ in
+        stub(condition: isPath(request.path)) { _ in
             HTTPStubsResponse(
                 data: data ?? request.sampleData,
                 statusCode: statusCode,

--- a/sample/Sample.xcodeproj/project.pbxproj
+++ b/sample/Sample.xcodeproj/project.pbxproj
@@ -11,11 +11,15 @@
 		04DED82F81FAABE856CDD4B6 /* NetworkStubber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C15DB43A088E7CEDCBAE2 /* NetworkStubber.swift */; };
 		07088992E0ABAC9DE8B9CDBE /* NetworkAPIProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B52A71E1543239FA293EE5 /* NetworkAPIProtocol.swift */; };
 		09111503B3814633D659F06B /* DummyRequestConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A222CB34D64142C1FF7760D /* DummyRequestConfiguration.swift */; };
+		11A7E0C2B4D6F8091A2B3C4D /* Quick in Frameworks */ = {isa = PBXBuildFile; productRef = B1CA1588ECB9A47697260A17 /* Quick */; };
 		0BBD3599422254801C200528 /* Constants+API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 824E2AB8BFAA3849931F33AE /* Constants+API.swift */; };
+		22B8F1D3C5E7A9012B3C4D5E /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 18F5A0AE0627651DDA63CBE0 /* Nimble */; };
 		0E2183805A67EBF9085073E3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 286DD4D76E2452C79E8648EE /* Assets.xcassets */; };
 		22296CE8499F72BF141B7D5F /* Domain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E07E37E84EF9C86B2879155C /* Domain.framework */; };
+		33C9A2E4D6F8B0123C4D5E6F /* OHHTTPStubs in Frameworks */ = {isa = PBXBuildFile; productRef = 66FCD51709CBE3456F708192 /* OHHTTPStubs */; };
 		307686EDE057509B66FFC845 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5DC698257D79F99DC62A11 /* Constants.swift */; };
 		3316F4109CDE146DCCAA741D /* Quick in Frameworks */ = {isa = PBXBuildFile; productRef = B1CA1588ECB9A47697260A17 /* Quick */; };
+		44DAB3F5E7A9C1234D5E6F70 /* Quick in Frameworks */ = {isa = PBXBuildFile; productRef = B1CA1588ECB9A47697260A17 /* Quick */; };
 		42F6AD7F0C0D3463775B80E0 /* UseCaseFactoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE21B903703DF03A9851E7D3 /* UseCaseFactoryProtocol.swift */; };
 		4A4A55ECFCC1F1CF7E0B65BD /* DummySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 184120E152561351469C4E21 /* DummySpec.swift */; };
 		4B32CF5B51AEF56F0E26F136 /* OptionalUnwrapSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E8A0397F340058194D8997 /* OptionalUnwrapSpec.swift */; };
@@ -43,6 +47,7 @@
 		DE136AF9C4C5401DC3BCF78D /* Optional+Unwrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FED59B28688202535C340B9 /* Optional+Unwrap.swift */; };
 		E3642D0289460A0852A06F36 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = E4C03B04B78A507440A85268 /* Alamofire */; };
 		EB33D0A59DE13A7CFB56B5B6 /* RequestConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBDEB7F1C339498236454DF1 /* RequestConfiguration.swift */; };
+		55EBC406F8BAD2345E6F7081 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 18F5A0AE0627651DDA63CBE0 /* Nimble */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -230,6 +235,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				896A5C45EAC7EC4209B9218D /* Data.framework in Frameworks */,
+				11A7E0C2B4D6F8091A2B3C4D /* Quick in Frameworks */,
+				22B8F1D3C5E7A9012B3C4D5E /* Nimble in Frameworks */,
+				33C9A2E4D6F8B0123C4D5E6F /* OHHTTPStubs in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -238,6 +246,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				22296CE8499F72BF141B7D5F /* Domain.framework in Frameworks */,
+				44DAB3F5E7A9C1234D5E6F70 /* Quick in Frameworks */,
+				55EBC406F8BAD2345E6F7081 /* Nimble in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -766,6 +776,9 @@
 			);
 			name = DataTests;
 			packageProductDependencies = (
+				B1CA1588ECB9A47697260A17 /* Quick */,
+				18F5A0AE0627651DDA63CBE0 /* Nimble */,
+				66FCD51709CBE3456F708192 /* OHHTTPStubs */,
 			);
 			productName = DataTests;
 			productReference = 6F7020EE066553E9B7ADCB04 /* DataTests.xctest */;
@@ -829,6 +842,8 @@
 			);
 			name = DomainTests;
 			packageProductDependencies = (
+				B1CA1588ECB9A47697260A17 /* Quick */,
+				18F5A0AE0627651DDA63CBE0 /* Nimble */,
 			);
 			productName = DomainTests;
 			productReference = D46C25B9DF44A7CBA6BC4FE0 /* DomainTests.xctest */;
@@ -2021,6 +2036,10 @@
 		482BFB794A61E294D2F8B274 /* OHHTTPStubsSwift */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = OHHTTPStubsSwift;
+		};
+		66FCD51709CBE3456F708192 /* OHHTTPStubs */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = OHHTTPStubs;
 		};
 		76C0B6E5B684B6FE084E5ED2 /* JSONAPIMapper */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/sample/Sample.xcodeproj/project.pbxproj
+++ b/sample/Sample.xcodeproj/project.pbxproj
@@ -16,7 +16,8 @@
 		22B8F1D3C5E7A9012B3C4D5E /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 18F5A0AE0627651DDA63CBE0 /* Nimble */; };
 		0E2183805A67EBF9085073E3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 286DD4D76E2452C79E8648EE /* Assets.xcassets */; };
 		22296CE8499F72BF141B7D5F /* Domain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E07E37E84EF9C86B2879155C /* Domain.framework */; };
-		33C9A2E4D6F8B0123C4D5E6F /* OHHTTPStubs in Frameworks */ = {isa = PBXBuildFile; productRef = 66FCD51709CBE3456F708192 /* OHHTTPStubs */; };
+		F4E3D2C1B0A9F8E7D6C5B4A3 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = BEF9E32E91F7609F6680E8F5 /* Alamofire */; };
+		A3B4C5D6E7F8091A2B3C4D5E /* OHHTTPStubsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 482BFB794A61E294D2F8B274 /* OHHTTPStubsSwift */; };
 		307686EDE057509B66FFC845 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5DC698257D79F99DC62A11 /* Constants.swift */; };
 		3316F4109CDE146DCCAA741D /* Quick in Frameworks */ = {isa = PBXBuildFile; productRef = B1CA1588ECB9A47697260A17 /* Quick */; };
 		44DAB3F5E7A9C1234D5E6F70 /* Quick in Frameworks */ = {isa = PBXBuildFile; productRef = B1CA1588ECB9A47697260A17 /* Quick */; };
@@ -237,7 +238,8 @@
 				896A5C45EAC7EC4209B9218D /* Data.framework in Frameworks */,
 				11A7E0C2B4D6F8091A2B3C4D /* Quick in Frameworks */,
 				22B8F1D3C5E7A9012B3C4D5E /* Nimble in Frameworks */,
-				33C9A2E4D6F8B0123C4D5E6F /* OHHTTPStubs in Frameworks */,
+				F4E3D2C1B0A9F8E7D6C5B4A3 /* Alamofire in Frameworks */,
+				A3B4C5D6E7F8091A2B3C4D5E /* OHHTTPStubsSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -778,7 +780,8 @@
 			packageProductDependencies = (
 				B1CA1588ECB9A47697260A17 /* Quick */,
 				18F5A0AE0627651DDA63CBE0 /* Nimble */,
-				66FCD51709CBE3456F708192 /* OHHTTPStubs */,
+				BEF9E32E91F7609F6680E8F5 /* Alamofire */,
+				482BFB794A61E294D2F8B274 /* OHHTTPStubsSwift */,
 			);
 			productName = DataTests;
 			productReference = 6F7020EE066553E9B7ADCB04 /* DataTests.xctest */;
@@ -1210,9 +1213,11 @@
 		43F15B66502A91B76FDA8D19 /* Debug Staging */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = SampleTests/Configurations/Plists/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "${PRODUCT_BUNDLE_IDENTIFIER}";
 				PRODUCT_NAME = SampleTests;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Sample.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Sample";
 				SDKROOT = iphoneos;
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -1224,9 +1229,11 @@
 		4BB5DC76B86371B93845AE1E /* Debug Production */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = SampleTests/Configurations/Plists/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "${PRODUCT_BUNDLE_IDENTIFIER}";
 				PRODUCT_NAME = SampleTests;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Sample.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Sample";
 				SDKROOT = iphoneos;
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -1286,9 +1293,11 @@
 		52F56E907402DEE345334D82 /* Release Staging */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = SampleTests/Configurations/Plists/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "${PRODUCT_BUNDLE_IDENTIFIER}";
 				PRODUCT_NAME = SampleTests;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Sample.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Sample";
 				SDKROOT = iphoneos;
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -1796,9 +1805,11 @@
 		F8D890567CC66EFFF56E4EC6 /* Release Production */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = SampleTests/Configurations/Plists/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "${PRODUCT_BUNDLE_IDENTIFIER}";
 				PRODUCT_NAME = SampleTests;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Sample.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Sample";
 				SDKROOT = iphoneos;
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -2036,10 +2047,6 @@
 		482BFB794A61E294D2F8B274 /* OHHTTPStubsSwift */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = OHHTTPStubsSwift;
-		};
-		66FCD51709CBE3456F708192 /* OHHTTPStubs */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = OHHTTPStubs;
 		};
 		76C0B6E5B684B6FE084E5ED2 /* JSONAPIMapper */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/sample/Sample.xcodeproj/xcshareddata/xcschemes/Sample Staging.xcscheme
+++ b/sample/Sample.xcodeproj/xcshareddata/xcschemes/Sample Staging.xcscheme
@@ -33,6 +33,28 @@
             parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EED8B50570C99D693C1442B9"
+               BuildableName = "DomainTests.xctest"
+               BlueprintName = "DomainTests"
+               ReferencedContainer = "container:Sample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "154479324AB242590A6BB276"
+               BuildableName = "DataTests.xctest"
+               BlueprintName = "DataTests"
+               ReferencedContainer = "container:Sample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "0EC7E0FF6972238953C4D7FA"
                BuildableName = "SampleTests.xctest"
                BlueprintName = "SampleTests"

--- a/sample/Sample.xcodeproj/xcshareddata/xcschemes/Sample.xcscheme
+++ b/sample/Sample.xcodeproj/xcshareddata/xcschemes/Sample.xcscheme
@@ -33,6 +33,28 @@
             parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EED8B50570C99D693C1442B9"
+               BuildableName = "DomainTests.xctest"
+               BlueprintName = "DomainTests"
+               ReferencedContainer = "container:Sample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "154479324AB242590A6BB276"
+               BuildableName = "DataTests.xctest"
+               BlueprintName = "DataTests"
+               ReferencedContainer = "container:Sample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "0EC7E0FF6972238953C4D7FA"
                BuildableName = "SampleTests.xctest"
                BlueprintName = "SampleTests"

--- a/sample/SampleTests/Sources/Specs/Supports/Extensions/Foundation/OptionalUnwrapSpec.swift
+++ b/sample/SampleTests/Sources/Specs/Supports/Extensions/Foundation/OptionalUnwrapSpec.swift
@@ -12,24 +12,16 @@ final class OptionalUnwrapSpec: QuickSpec {
     override class func spec() {
 
         describe("an string optional") {
-            var value: String?
-
             context("when value is not nil") {
-                beforeEach {
-                    value = "hello world"
-                }
-
                 it("returns string with unwrap value") {
+                    let value: String? = "hello world"
                     expect(value.string) == "hello world"
                 }
             }
 
             context("when value is nil") {
-                beforeEach {
-                    value = nil
-                }
-
                 it("returns empty string") {
+                    let value: String? = nil
                     expect(value.string.isEmpty) == true
                 }
             }

--- a/template/Modules/Data/Tests/Sources/Dummies/DummyRequestConfiguration.swift
+++ b/template/Modules/Data/Tests/Sources/Dummies/DummyRequestConfiguration.swift
@@ -20,8 +20,8 @@ struct DummyRequestConfiguration: RequestConfiguration {
 
 extension DummyRequestConfiguration: RequestConfigurationStubable {
 
-    var sampleData: Data {
-        DummyNetworkModel.json.data(using: .utf8) ?? Data()
+    var sampleData: Foundation.Data {
+        DummyNetworkModel.json.data(using: .utf8) ?? Foundation.Data()
     }
 
     var path: String {

--- a/template/Modules/Data/Tests/Sources/Specs/NetworkAPI/NetworkAPISpec.swift
+++ b/template/Modules/Data/Tests/Sources/Specs/NetworkAPI/NetworkAPISpec.swift
@@ -2,6 +2,7 @@
 //  NetworkAPISpec.swift
 //
 
+import Foundation
 import Nimble
 import Quick
 
@@ -30,7 +31,7 @@ final class NetworkAPISpec: AsyncSpec {
                 context("when network returns value") {
 
                     beforeEach {
-                        NetworkStubber.stub(requestConfiguration)
+                        NetworkStubber.addStub(requestConfiguration)
                         networkAPI = NetworkAPI()
                     }
 
@@ -46,7 +47,7 @@ final class NetworkAPISpec: AsyncSpec {
                 context("when network returns error") {
 
                     beforeEach {
-                        NetworkStubber.stub(requestConfiguration, data: Data(), statusCode: 400)
+                        NetworkStubber.addStub(requestConfiguration, data: Foundation.Data(), statusCode: 400)
                         networkAPI = NetworkAPI()
                     }
 

--- a/template/Modules/Data/Tests/Sources/Utilities/NetworkStubber.swift
+++ b/template/Modules/Data/Tests/Sources/Utilities/NetworkStubber.swift
@@ -2,11 +2,13 @@
 //  NetworkStubber.swift
 //
 
+import Foundation
 import OHHTTPStubs
+import OHHTTPStubsSwift
 
 protocol RequestConfigurationStubable {
 
-    var sampleData: Data { get }
+    var sampleData: Foundation.Data { get }
     var path: String { get }
 }
 
@@ -16,12 +18,12 @@ enum NetworkStubber {
         HTTPStubs.removeAllStubs()
     }
 
-    static func stub(
+    static func addStub(
         _ request: RequestConfigurationStubable,
-        data: Data? = nil,
+        data: Foundation.Data? = nil,
         statusCode: Int32 = 200
     ) {
-        OHHTTPStubs.stub(condition: isPath(request.path)) { _ in
+        stub(condition: isPath(request.path)) { _ in
             HTTPStubsResponse(
                 data: data ?? request.sampleData,
                 statusCode: statusCode,

--- a/template/Tuist/ProjectDescriptionHelpers/Scheme+Initializing.swift
+++ b/template/Tuist/ProjectDescriptionHelpers/Scheme+Initializing.swift
@@ -9,7 +9,7 @@ extension Scheme {
             name: name,
             shared: true,
             buildAction: .buildAction(targets: ["\(name)"]),
-            testAction: TestAction.targets([.testableTarget(target: "\(name)Tests")], configuration: debugConfigName),
+            testAction: TestAction.targets(testTargets(for: name), configuration: debugConfigName),
             runAction: .runAction(configuration: debugConfigName),
             archiveAction: .archiveAction(configuration: releaseConfigName)
         )
@@ -23,7 +23,7 @@ extension Scheme {
             name: "\(name) Staging",
             shared: true,
             buildAction: .buildAction(targets: ["\(name)"]),
-            testAction: TestAction.targets([.testableTarget(target: "\(name)Tests")], configuration: debugConfigName),
+            testAction: TestAction.targets(testTargets(for: name), configuration: debugConfigName),
             runAction: .runAction(configuration: debugConfigName),
             archiveAction: .archiveAction(configuration: releaseConfigName)
         )
@@ -37,9 +37,17 @@ extension Scheme {
             name: "\(name) Dev",
             shared: true,
             buildAction: .buildAction(targets: ["\(name)"]),
-            testAction: TestAction.targets([.testableTarget(target: "\(name)Tests")], configuration: debugConfigName),
+            testAction: TestAction.targets(testTargets(for: name), configuration: debugConfigName),
             runAction: .runAction(configuration: debugConfigName),
             archiveAction: .archiveAction(configuration: releaseConfigName),
         )
+    }
+
+    private static func testTargets(for name: String) -> [TestableTarget] {
+        [
+            .testableTarget(target: "\(Module.domain.name)\(Constant.testsPath)"),
+            .testableTarget(target: "\(Module.data.name)\(Constant.testsPath)"),
+            .testableTarget(target: "\(name)Tests")
+        ]
     }
 }

--- a/template/Tuist/ProjectDescriptionHelpers/Target+Initializing.swift
+++ b/template/Tuist/ProjectDescriptionHelpers/Target+Initializing.swift
@@ -87,12 +87,25 @@ extension Target {
             bundleId: module.testBundleId(mainBundleId: bundleId),
             sources: module.testsSources,
             resources: module.testsResources,
-            dependencies: [
-                .target(name: module.name)
-            ]
+            dependencies: moduleTestDependencies(for: module)
         )
 
         return [framework, testTarget]
+    }
+
+    fileprivate static func moduleTestDependencies(for module: Module) -> [TargetDependency] {
+        var dependencies: [TargetDependency] = [
+            .target(name: module.name),
+            .package(product: "Quick"),
+            .package(product: "Nimble")
+        ]
+
+        if module == .data {
+            dependencies.append(.package(product: "Alamofire"))
+            dependencies.append(.package(product: "OHHTTPStubsSwift"))
+        }
+
+        return dependencies
     }
 
     fileprivate static func testsTarget(name: String, bundleId: String) -> Target {
@@ -110,7 +123,14 @@ extension Target {
                 .package(product: "Quick"),
                 .package(product: "Nimble"),
                 .package(product: "OHHTTPStubsSwift"), // From OHHTTPStubs package
-            ]
+            ],
+            settings: .settings(
+                base: [
+                    // Host app binary must load for `@testable import` (e.g. app-only extensions).
+                    "BUNDLE_LOADER": "$(TEST_HOST)",
+                    "TEST_HOST": "$(BUILT_PRODUCTS_DIR)/\(name).app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/\(name)"
+                ]
+            )
         )
     }
 }

--- a/template/{PROJECT_NAME}Tests/Sources/Specs/Supports/Extensions/Foundation/OptionalUnwrapSpec.swift
+++ b/template/{PROJECT_NAME}Tests/Sources/Specs/Supports/Extensions/Foundation/OptionalUnwrapSpec.swift
@@ -12,24 +12,16 @@ final class OptionalUnwrapSpec: QuickSpec {
     override class func spec() {
 
         describe("an string optional") {
-            var value: String?
-
             context("when value is not nil") {
-                beforeEach {
-                    value = "hello world"
-                }
-
                 it("returns string with unwrap value") {
+                    let value: String? = "hello world"
                     expect(value.string) == "hello world"
                 }
             }
 
             context("when value is nil") {
-                beforeEach {
-                    value = nil
-                }
-
                 it("returns empty string") {
+                    let value: String? = nil
                     expect(value.string.isEmpty) == true
                 }
             }


### PR DESCRIPTION
- Close #644 

## What happened 👀

This PR makes **Domain** and **Data** unit tests run when you test from the **default app schemes** (Production, Staging, Dev), instead of only the app unit test target.

Previously, `TestAction` on those schemes listed only `{ProjectName}Tests`, so `DomainTests` and `DataTests` did not run unless you picked their own schemes.

Along with wiring schemes, this PR fixes **generated** test setup so those runs **build and pass**:

- **Schemes:** Each app scheme’s `testAction` now includes **DomainTests**, **DataTests**, and **{ProjectName}Tests** (same order as in Tuist).
- **App unit tests:** `TEST_HOST` / `BUNDLE_LOADER` on `{ProjectName}Tests` so `@testable import` of the app resolves when tests are driven from the app scheme.
- **DataTests:** Declares **Quick**, **Nimble**, **Alamofire**, and **OHHTTPStubsSwift** so Data layer specs and HTTP stubs link.
- **Template tests:** Fixes for current Swift / stubs — **`Foundation.Data`** where `import Data` shadows Foundation, **`NetworkStubber.addStub`** vs `stub(...)`, and **OptionalUnwrapSpec** adjusted for Swift 6 concurrency.

**Sample project (`sample/`):** mirrors the same behavior so the checked-in Xcode project matches the template:

- App schemes include Domain/Data/app tests.
- **DataTests** links **Alamofire** and **OHHTTPStubsSwift** (not only the `OHHTTPStubs` product).
- **SampleTests** sets `TEST_HOST` / `BUNDLE_LOADER` for `@testable import Sample`.
- **OptionalUnwrapSpec** matches the template Swift 6 pattern.

## Insight 📝

The module test **targets** were already there; the gap was **scheme `TestAction`** not listing them, plus **host / linker / package** wiring once those targets run from the default app scheme.

After this change, **`tuist generate`** and the **sample** project both run the full suite from the main app schemes without extra manual scheme selection.

### How to test

1. **Template:** Generate a project from the template, run `tuist generate`, then **Test** from the main app scheme (and Staging / Dev if you use them). Confirm **DomainTests**, **DataTests**, and app tests all run and pass.
2. **Sample:** Open `sample/`, select **Sample** (and **Sample Staging**), run tests, and confirm **DomainTests**, **DataTests**, and **SampleTests** run and pass.

## Proof Of Work 📹

**CI/CD successfully**

<img width="280" height="380" alt="Screenshot 2026-04-06 at 13 04 59" src="https://github.com/user-attachments/assets/e153ca59-7265-4d52-8502-1f568e3d9207" />

<img width="409" height="282" alt="Screenshot 2026-04-06 at 13 19 00" src="https://github.com/user-attachments/assets/14bab5ba-3f16-4bd9-ac95-5b55d80f2343" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test suite to include Domain and Data module tests in build schemes.
  * Improved test isolation by using independent test values instead of shared state.

* **Chores**
  * Added testing framework dependencies to test targets.
  * Updated Xcode build configuration for proper test target linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->