### PR TITLE
[#653] Pin GitHub Actions to commit SHAs and enable Dependabot updates [Part 1]

### DIFF
--- a/.cicdtemplate/.github/actions/setup-ci-environment/action.yml
+++ b/.cicdtemplate/.github/actions/setup-ci-environment/action.yml
@@ -31,14 +31,14 @@ runs:
   using: composite
   steps:
     - name: Setup Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # ruby/setup-ruby@v1.300.0
       with:
         ruby-version: ${{ inputs.ruby-version }}
         bundler-cache: ${{ inputs.bundler-cache }}
 
     - name: Install tools with mise
       if: ${{ inputs.setup-mise == 'true' }}
-      uses: jdx/mise-action@v4.0.1
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # jdx/mise-action@v4.0.1
 
     - name: Bundle install
       if: ${{ inputs.run-bundle-install == 'true' && inputs.bundler-cache != 'true' }}

--- a/.cicdtemplate/.github/self-hosted-workflows/automatic_pull_request_review.yml
+++ b/.cicdtemplate/.github/self-hosted-workflows/automatic_pull_request_review.yml
@@ -13,11 +13,11 @@ jobs:
     name: Pull request review by Danger
     runs-on: [self-hosted, macOS]
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
         fetch-depth: 0
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # actions/cache@v4.3.0
       id: bunlderCache
       with:
         path: vendor/bundle
@@ -26,7 +26,7 @@ jobs:
           ${{ runner.os }}-gems-
 
     - name: Install tools with mise
-      uses: jdx/mise-action@v4.0.1
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # jdx/mise-action@v4.0.1
 
     - name: Setup ENV file
       env:

--- a/.cicdtemplate/.github/self-hosted-workflows/automatic_pull_request_review.yml
+++ b/.cicdtemplate/.github/self-hosted-workflows/automatic_pull_request_review.yml
@@ -17,8 +17,8 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # actions/cache@v4.3.0
-      id: bunlderCache
+    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # actions/cache@v5.0.4
+      id: bundlerCache
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}

--- a/.cicdtemplate/.github/self-hosted-workflows/draft_a_new_release.yml
+++ b/.cicdtemplate/.github/self-hosted-workflows/draft_a_new_release.yml
@@ -13,6 +13,6 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # release-drafter/release-drafter@v7.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.cicdtemplate/.github/self-hosted-workflows/publish_docs_to_wiki.yml
+++ b/.cicdtemplate/.github/self-hosted-workflows/publish_docs_to_wiki.yml
@@ -31,7 +31,7 @@ jobs:
       TARGET_WIKI_DIR: tmp_wiki
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
 
       - name: Validate wiki publishing configuration
         run: |

--- a/.cicdtemplate/.github/workflows/automatic_pull_request_review.yml
+++ b/.cicdtemplate/.github/workflows/automatic_pull_request_review.yml
@@ -13,11 +13,11 @@ jobs:
     name: Pull request review by Danger
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
         fetch-depth: 0
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # actions/cache@v4.3.0
       id: bunlderCache
       with:
         path: vendor/bundle

--- a/.cicdtemplate/.github/workflows/automatic_pull_request_review.yml
+++ b/.cicdtemplate/.github/workflows/automatic_pull_request_review.yml
@@ -17,8 +17,8 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # actions/cache@v4.3.0
-      id: bunlderCache
+    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # actions/cache@v5.0.4
+      id: bundlerCache
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}

--- a/.cicdtemplate/.github/workflows/bump_version.yaml
+++ b/.cicdtemplate/.github/workflows/bump_version.yaml
@@ -24,14 +24,14 @@ jobs:
             exit 1
           fi
       - name: Create Bump Version branch
-        uses: peterjgrainger/action-create-branch@v2.2.0
+        uses: peterjgrainger/action-create-branch@c2800a3a9edbba2218da6861fa46496cf8f3195a # peterjgrainger/action-create-branch@v2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           branch: chore/bump-version-to-${{ github.event.inputs.nextVersion }}
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
         with:
           ref: chore/bump-version-to-${{ github.event.inputs.nextVersion }}
 

--- a/.cicdtemplate/.github/workflows/create_release_pull_request.yml
+++ b/.cicdtemplate/.github/workflows/create_release_pull_request.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
 
       - name: Get release version
         run: |
@@ -22,7 +22,7 @@ jobs:
           echo $release_version
           echo "RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
 
-      - uses: nimblehq/github-actions-workflows/create_release_pull_request@0.1.10
+      - uses: nimblehq/github-actions-workflows/create_release_pull_request@d2f913f1faba9dd814eb0cab86147d2bab6e0e34 # nimblehq/github-actions-workflows/create_release_pull_request@v0.1.10
         with:
           release_version: ${{ env.RELEASE_VERSION }}
           changelog_configuration: ".github/workflows/configs/changelog-config.json"

--- a/.cicdtemplate/.github/workflows/draft_a_new_release.yml
+++ b/.cicdtemplate/.github/workflows/draft_a_new_release.yml
@@ -13,6 +13,6 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # release-drafter/release-drafter@v7.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.cicdtemplate/.github/workflows/publish_docs_to_wiki.yml
+++ b/.cicdtemplate/.github/workflows/publish_docs_to_wiki.yml
@@ -31,7 +31,7 @@ jobs:
       TARGET_WIKI_DIR: tmp_wiki
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
 
       - name: Validate wiki publishing configuration
         run: |

--- a/.github/actions/setup-ci-environment/action.yml
+++ b/.github/actions/setup-ci-environment/action.yml
@@ -31,14 +31,14 @@ runs:
   using: composite
   steps:
     - name: Setup Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # ruby/setup-ruby@v1.300.0
       with:
         ruby-version: ${{ inputs.ruby-version }}
         bundler-cache: ${{ inputs.bundler-cache }}
 
     - name: Install tools with mise
       if: ${{ inputs.setup-mise == 'true' }}
-      uses: jdx/mise-action@v4.0.1
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # jdx/mise-action@v4.0.1
 
     - name: Bundle install
       if: ${{ inputs.run-bundle-install == 'true' && inputs.bundler-cache != 'true' }}

--- a/.github/workflows/cleanup_cache.yml
+++ b/.github/workflows/cleanup_cache.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macOS-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
 
       - name: Cleanup
         run: |

--- a/.github/workflows/draft_a_new_release.yml
+++ b/.github/workflows/draft_a_new_release.yml
@@ -13,6 +13,6 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # release-drafter/release-drafter@v7.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -31,7 +31,7 @@ jobs:
       TARGET_WIKI_DIR: tmp_wiki
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
 
       - name: Validate wiki publishing configuration
         run: |

--- a/.github/workflows/verify_newproject_script.yml
+++ b/.github/workflows/verify_newproject_script.yml
@@ -15,7 +15,7 @@ jobs:
       CI: true
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
 
     - name: Copy mise config
       run: cp template/.mise.toml .mise.toml


### PR DESCRIPTION
- Close #653 

## What happened 👀

- Pin third-party GitHub Actions in the table below to full commit SHAs.
- This part covers documentation, release housekeeping, PR review automation, and the shared setup-ci-environment composite (under .github/, .cicdtemplate/).

## Insight 📝
Part 2:

- Upload build and deploy workflows.
- Add `Dependabot` for package-ecosystem: `github-actions` in `.github/dependabot.yml`.
## Proof Of Work 📹

| Before | After |
|--------|--------|
| actions/checkout@v4/5/6 | [actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd](https://github.com/actions/checkout/releases/tag/v6.0.2) # actions/checkout@v6.0.2
| actions/cache@v4 | [actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7](https://github.com/actions/cache/releases/tag/v5.0.4) # actions/cache@v5.0.4
| release-drafter/release-drafter@v5/7 | [release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2](https://github.com/release-drafter/release-drafter/releases/tag/v7.1.1) # release-drafter/release-drafter@v7.1.1 |
| ruby/setup-ruby@v1 | [ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92](https://github.com/ruby/setup-ruby/releases/tag/v1.300.0) # ruby/setup-ruby@v1.300.0|
| jdx/mise-action@v4.0.1 | [jdx/mise-action@1648a7812b9aeae629881980618f079932869151](https://github.com/jdx/mise-action/releases/tag/v4.0.1) # jdx/mise-action@v4.0.1 |
| nimblehq/github-actions-workflows/create_release_pull_request@0.1.10 | [nimblehq/github-actions-workflows/create_release_pull_request@d2f913f1faba9dd814eb0cab86147d2bab6e0e34](https://github.com/nimblehq/github-actions-workflows/releases/tag/0.1.10) # nimblehq/github-actions-workflows/create_release_pull_request@v0.1.10 |
| peterjgrainger/action-create-branch@v2.2.0 | [peterjgrainger/action-create-branch@c2800a3a9edbba2218da6861fa46496cf8f3195a](https://github.com/peterjgrainger/action-create-branch/releases/tag/v2.2.0) # peterjgrainger/action-create-branch@v2.2.0 |

- automatic_pull_request_review
<img width="966" height="672" alt="Screenshot 2026-04-08 at 12 56 37" src="https://github.com/user-attachments/assets/53329265-9b1a-4e73-84f6-8af93d2603e5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD stability and security by pinning GitHub Actions dependencies to specific versions across all workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->