### PR TITLE
[#653] Pin GitHub Actions to commit SHAs and enable Dependabot updates [Part 2]

### DIFF
--- a/.cicdtemplate/.github/self-hosted-workflows/deploy_app_store.yml
+++ b/.cicdtemplate/.github/self-hosted-workflows/deploy_app_store.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
         fetch-depth: 0
     - uses: ./.github/actions/swiftlint
@@ -32,13 +32,13 @@ jobs:
     runs-on: [self-hosted, macOS]
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
     # Set fetch-depth (default: 1) to get whole tree
       with:
         fetch-depth: 0
 
     - name: Install SSH key
-      uses: webfactory/ssh-agent@v0.7.0
+      uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
@@ -50,7 +50,7 @@ jobs:
         echo $ENV | base64 --decode > .env
 
     - name: Install tools with mise
-      uses: jdx/mise-action@v4.0.1
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # jdx/mise-action@v4.0.1
 
     - name: Bundle install
       run: bundle install
@@ -75,7 +75,7 @@ jobs:
         BUMP_APP_STORE_BUILD_NUMBER: "true"
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4.6.2
       with:
         name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
         path: |

--- a/.cicdtemplate/.github/self-hosted-workflows/deploy_production_firebase.yml
+++ b/.cicdtemplate/.github/self-hosted-workflows/deploy_production_firebase.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
         fetch-depth: 0
     - uses: ./.github/actions/swiftlint
@@ -29,13 +29,13 @@ jobs:
     name: Build
     runs-on: [self-hosted, macOS]
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
     # Set fetch-depth (default: 1) to get whole tree
       with:
         fetch-depth: 0
 
     - name: Install SSH key
-      uses: webfactory/ssh-agent@v0.7.0
+      uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
@@ -48,13 +48,13 @@ jobs:
 
     - name: Read Google Service Account
       id: firebase_service_account
-      uses: timheuer/base64-to-file@v1.2
+      uses: timheuer/base64-to-file@adaa40c0c581f276132199d4cf60afa07ce60eac # timheuer/base64-to-file@v1.2
       with:
         fileName: 'firebase_service_account.json'
         encodedString: ${{ secrets.FIREBASE_GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
 
     - name: Install tools with mise
-      uses: jdx/mise-action@v4.0.1
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # jdx/mise-action@v4.0.1
 
     - name: Bundle install
       run: bundle install
@@ -76,7 +76,7 @@ jobs:
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.firebase_service_account.outputs.filePath }}
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4.6.2
       with:
         name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
         path: |

--- a/.cicdtemplate/.github/self-hosted-workflows/deploy_staging_firebase.yml
+++ b/.cicdtemplate/.github/self-hosted-workflows/deploy_staging_firebase.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
         fetch-depth: 0
     - uses: ./.github/actions/swiftlint
@@ -29,13 +29,13 @@ jobs:
     name: Build
     runs-on: [self-hosted, macOS]
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
     # Set fetch-depth (default: 1) to get whole tree
       with:
         fetch-depth: 0
 
     - name: Install SSH key
-      uses: webfactory/ssh-agent@v0.7.0
+      uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
@@ -53,13 +53,13 @@ jobs:
 
     - name: Read Google Service Account
       id: firebase_service_account
-      uses: timheuer/base64-to-file@v1.2
+      uses: timheuer/base64-to-file@adaa40c0c581f276132199d4cf60afa07ce60eac # timheuer/base64-to-file@v1.2
       with:
         fileName: 'firebase_service_account.json'
         encodedString: ${{ secrets.FIREBASE_GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
 
     - name: Install tools with mise
-      uses: jdx/mise-action@v4.0.1
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # jdx/mise-action@v4.0.1
 
     - name: Bundle install
       # if: steps.bundleCache.outputs.cache-hit != 'true'
@@ -82,7 +82,7 @@ jobs:
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.firebase_service_account.outputs.filePath }}
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4.6.2
       with:
         name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
         path: |

--- a/.cicdtemplate/.github/workflows/add_device_profile.yml
+++ b/.cicdtemplate/.github/workflows/add_device_profile.yml
@@ -30,12 +30,12 @@ jobs:
     runs-on: macOS-latest
     steps:
     - name: Checkout the repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
         fetch-depth: 0
 
     - name: Install SSH key
-      uses: webfactory/ssh-agent@v0.5.4
+      uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.cicdtemplate/.github/workflows/deploy_app_store.yml
+++ b/.cicdtemplate/.github/workflows/deploy_app_store.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
         fetch-depth: 0
     - uses: ./.github/actions/swiftlint
@@ -32,13 +32,13 @@ jobs:
     runs-on: macOS-latest
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
     # Set fetch-depth (default: 1) to get whole tree
       with:
         fetch-depth: 0
 
     - name: Install SSH key
-      uses: webfactory/ssh-agent@v0.7.0
+      uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
@@ -72,7 +72,7 @@ jobs:
         BUMP_APP_STORE_BUILD_NUMBER: "true"
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4.6.2
       with:
         name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
         path: |

--- a/.cicdtemplate/.github/workflows/deploy_dev_firebase.yml
+++ b/.cicdtemplate/.github/workflows/deploy_dev_firebase.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
         fetch-depth: 0
     - uses: ./.github/actions/swiftlint
@@ -29,7 +29,7 @@ jobs:
     name: Build
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
         fetch-depth: 0
 
@@ -40,7 +40,7 @@ jobs:
         echo "EOF" >> $GITHUB_ENV
 
     - name: Install SSH key
-      uses: webfactory/ssh-agent@v0.7.0
+      uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
@@ -57,7 +57,7 @@ jobs:
 
     - name: Read Google Service Account
       id: firebase_service_account
-      uses: timheuer/base64-to-file@v1.2
+      uses: timheuer/base64-to-file@adaa40c0c581f276132199d4cf60afa07ce60eac # timheuer/base64-to-file@v1.2
       with:
         fileName: 'firebase_service_account.json'
         encodedString: ${{ secrets.FIREBASE_GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
@@ -82,7 +82,7 @@ jobs:
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.firebase_service_account.outputs.filePath }}
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4.6.2
       with:
         name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
         path: |

--- a/.cicdtemplate/.github/workflows/deploy_production_firebase.yml
+++ b/.cicdtemplate/.github/workflows/deploy_production_firebase.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
         fetch-depth: 0
     - uses: ./.github/actions/swiftlint
@@ -29,13 +29,13 @@ jobs:
     name: Build
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
     # Set fetch-depth (default: 1) to get whole tree
       with:
         fetch-depth: 0
 
     - name: Install SSH key
-      uses: webfactory/ssh-agent@v0.7.0
+      uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
@@ -47,7 +47,7 @@ jobs:
 
     - name: Read Google Service Account
       id: firebase_service_account
-      uses: timheuer/base64-to-file@v1.2
+      uses: timheuer/base64-to-file@adaa40c0c581f276132199d4cf60afa07ce60eac # timheuer/base64-to-file@v1.2
       with:
         fileName: 'firebase_service_account.json'
         encodedString: ${{ secrets.FIREBASE_GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
@@ -72,7 +72,7 @@ jobs:
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.firebase_service_account.outputs.filePath }}
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4.6.2
       with:
         name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
         path: |

--- a/.cicdtemplate/.github/workflows/deploy_staging_firebase.yml
+++ b/.cicdtemplate/.github/workflows/deploy_staging_firebase.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
         fetch-depth: 0
     - uses: ./.github/actions/swiftlint
@@ -29,7 +29,7 @@ jobs:
     name: Build
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
     # Set fetch-depth (default: 1) to get whole tree
       with:
         fetch-depth: 0
@@ -41,7 +41,7 @@ jobs:
         echo "EOF" >> $GITHUB_ENV
 
     - name: Install SSH key
-      uses: webfactory/ssh-agent@v0.7.0
+      uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
@@ -58,7 +58,7 @@ jobs:
 
     - name: Read Google Service Account
       id: firebase_service_account
-      uses: timheuer/base64-to-file@v1.2
+      uses: timheuer/base64-to-file@adaa40c0c581f276132199d4cf60afa07ce60eac # timheuer/base64-to-file@v1.2
       with:
         fileName: 'firebase_service_account.json'
         encodedString: ${{ secrets.FIREBASE_GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
@@ -83,7 +83,7 @@ jobs:
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.firebase_service_account.outputs.filePath }}
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4.6.2
       with:
         name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
         path: |

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.cicdtemplate"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test_upload_build_staging_to_firebase.yml
+++ b/.github/workflows/test_upload_build_staging_to_firebase.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
         fetch-depth: 0
     - uses: ./.github/actions/swiftlint
@@ -31,7 +31,7 @@ jobs:
     runs-on: macOS-latest
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
         fetch-depth: 0
 
@@ -42,7 +42,7 @@ jobs:
         echo "EOF" >> $GITHUB_ENV
 
     - name: Install SSH key
-      uses: webfactory/ssh-agent@v0.7.0
+      uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
@@ -59,7 +59,7 @@ jobs:
 
     - name: Read Google Service Account
       id: firebase_service_account
-      uses: timheuer/base64-to-file@v1.2
+      uses: timheuer/base64-to-file@adaa40c0c581f276132199d4cf60afa07ce60eac # timheuer/base64-to-file@v1.2
       with:
         fileName: "firebase_service_account.json"
         encodedString: ${{ secrets.FIREBASE_GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
@@ -87,7 +87,7 @@ jobs:
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.firebase_service_account.outputs.filePath }}
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4.6.2
       with:
         name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
         path: |

--- a/.github/workflows/test_upload_build_to_test_flight.yml
+++ b/.github/workflows/test_upload_build_to_test_flight.yml
@@ -26,12 +26,12 @@ jobs:
       FASTLANE_XCODEBUILD_SETTINGS_RETRIES: 4
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
         fetch-depth: 0
 
     - name: Install SSH key
-      uses: webfactory/ssh-agent@v0.7.0
+      uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
@@ -39,7 +39,7 @@ jobs:
       uses: ./.github/actions/setup-ci-environment
 
     - name: Cache SPM Packages
-      uses: actions/cache@v4
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # actions/cache@v5.0.4
       id: spmCache
       with:
         path: .build

--- a/.github/workflows/test_upload_dev_build_to_firebase.yml
+++ b/.github/workflows/test_upload_dev_build_to_firebase.yml
@@ -24,7 +24,7 @@ jobs:
       FASTLANE_XCODEBUILD_SETTINGS_RETRIES: 4
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
         fetch-depth: 0
 
@@ -37,7 +37,7 @@ jobs:
         echo "EOF" >> $GITHUB_ENV
 
     - name: Install SSH key
-      uses: webfactory/ssh-agent@v0.7.0
+      uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
@@ -48,7 +48,7 @@ jobs:
 
     - name: Read Google Service Account
       id: firebase_service_account
-      uses: timheuer/base64-to-file@v1.2
+      uses: timheuer/base64-to-file@adaa40c0c581f276132199d4cf60afa07ce60eac # timheuer/base64-to-file@v1.2
       with:
         fileName: 'firebase_service_account.json'
         encodedString: ${{ secrets.FIREBASE_GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
@@ -79,7 +79,7 @@ jobs:
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.firebase_service_account.outputs.filePath }}
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4.6.2
       with:
         name: ${{ format('v{0}({1})-{2}', env.VERSION_NUMBER, env.BUILD_NUMBER, env.TAG_TYPE) }}
         path: |


### PR DESCRIPTION
- Close #653 

## What happened 👀

- Pin third-party GitHub Actions in the table below to full commit SHAs ( also upgrade it to the latest version if available )
- This part covers build and deploy workflows.
- Add `Dependabot` for package-ecosystem: "github-actions" .

## Insight 📝

N/A

## Proof Of Work 📹
| Before | After |
|--------|--------|
| actions/checkout@v4/5/6 | [actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd](https://github.com/actions/checkout/releases/tag/v6.0.2) # actions/checkout@v6.0.2  |
| webfactory/ssh-agent@v0.7.0 | [webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2](https://github.com/webfactory/ssh-agent/releases/tag/v0.7.0) # webfactory/ssh-agent@v0.7.0 |
| timheuer/base64-to-file@v1.2  | [timheuer/base64-to-file@adaa40c0c581f276132199d4cf60afa07ce60eac](https://github.com/timheuer/base64-to-file/releases/tag/v1.2) # timheuer/base64-to-file@v1.2 |
| actions/upload-artifact@v4 | [actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830](https://github.com/actions/cache/releases/tag/v4.3.0) # actions/cache@v4.3.0 |
| jdx/mise-action@v4.0.1 | [jdx/mise-action@1648a7812b9aeae629881980618f079932869151](https://github.com/jdx/mise-action/releases/tag/v4.0.1) # jdx/mise-action@v4.0.1 | 
| actions/cache@v4 | [actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7](https://github.com/actions/cache/releases/tag/v5.0.4) # actions/cache@v5.0.4 |

<img width="993" height="744" alt="Screenshot 2026-04-08 at 16 53 34" src="https://github.com/user-attachments/assets/f347195e-a65b-4362-9941-11293e577158" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to pin third‑party action references to specific revisions for more stable builds.
  * Added Dependabot configuration to enable automated weekly monitoring of GitHub Actions dependencies.
  * No runtime or workflow behavior was changed; only external action references and dependency monitoring were adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->