### PR TITLE
[#668] Shallow checkout where the full history isn't required

### DIFF
--- a/.cicdtemplate/.github/self-hosted-workflows/deploy_app_store.yml
+++ b/.cicdtemplate/.github/self-hosted-workflows/deploy_app_store.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     - uses: ./.github/actions/swiftlint
 
   build:
@@ -33,9 +33,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
-    # Set fetch-depth (default: 1) to get whole tree
       with:
-        fetch-depth: 0
+        fetch-depth: 1
 
     - name: Install SSH key
       uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # webfactory/ssh-agent@v0.7.0

--- a/.cicdtemplate/.github/self-hosted-workflows/deploy_production_firebase.yml
+++ b/.cicdtemplate/.github/self-hosted-workflows/deploy_production_firebase.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     - uses: ./.github/actions/swiftlint
 
   deploy:
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Build and Deploy to Firebase
         uses: ./.github/actions/build-and-deploy-firebase

--- a/.cicdtemplate/.github/self-hosted-workflows/deploy_staging_firebase.yml
+++ b/.cicdtemplate/.github/self-hosted-workflows/deploy_staging_firebase.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     - uses: ./.github/actions/swiftlint
 
   deploy:
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           
       - name: Build and Deploy to Firebase
         uses: ./.github/actions/build-and-deploy-firebase

--- a/.cicdtemplate/.github/self-hosted-workflows/publish_docs_to_wiki.yml
+++ b/.cicdtemplate/.github/self-hosted-workflows/publish_docs_to_wiki.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
+        with:
+          fetch-depth: 1
 
       - name: Validate wiki publishing configuration
         run: |

--- a/.cicdtemplate/.github/workflows/add_device_profile.yml
+++ b/.cicdtemplate/.github/workflows/add_device_profile.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Checkout the repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
-        fetch-depth: 0
+        fetch-depth: 1
 
     - name: Install SSH key
       uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # webfactory/ssh-agent@v0.7.0

--- a/.cicdtemplate/.github/workflows/bump_version.yaml
+++ b/.cicdtemplate/.github/workflows/bump_version.yaml
@@ -33,6 +33,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
         with:
+          fetch-depth: 1
           ref: chore/bump-version-to-${{ github.event.inputs.nextVersion }}
 
       - name: Bump version

--- a/.cicdtemplate/.github/workflows/create_release_pull_request.yml
+++ b/.cicdtemplate/.github/workflows/create_release_pull_request.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
+        with:
+          fetch-depth: 1
 
       - name: Get release version
         run: |

--- a/.cicdtemplate/.github/workflows/deploy_app_store.yml
+++ b/.cicdtemplate/.github/workflows/deploy_app_store.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     - uses: ./.github/actions/swiftlint
 
   build:
@@ -33,9 +33,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
-    # Set fetch-depth (default: 1) to get whole tree
       with:
-        fetch-depth: 0
+        fetch-depth: 1
 
     - name: Install SSH key
       uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # webfactory/ssh-agent@v0.7.0

--- a/.cicdtemplate/.github/workflows/deploy_dev_firebase.yml
+++ b/.cicdtemplate/.github/workflows/deploy_dev_firebase.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     - uses: ./.github/actions/swiftlint
 
   deploy:
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Build and Deploy to Firebase
         uses: ./.github/actions/build-and-deploy-firebase

--- a/.cicdtemplate/.github/workflows/deploy_production_firebase.yml
+++ b/.cicdtemplate/.github/workflows/deploy_production_firebase.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     - uses: ./.github/actions/swiftlint
 
   deploy:
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           
       - name: Build and Deploy to Firebase
         uses: ./.github/actions/build-and-deploy-firebase

--- a/.cicdtemplate/.github/workflows/deploy_staging_firebase.yml
+++ b/.cicdtemplate/.github/workflows/deploy_staging_firebase.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     - uses: ./.github/actions/swiftlint
 
   deploy:
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           
       - name: Build and Deploy to Firebase
         uses: ./.github/actions/build-and-deploy-firebase

--- a/.cicdtemplate/.github/workflows/publish_docs_to_wiki.yml
+++ b/.cicdtemplate/.github/workflows/publish_docs_to_wiki.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
+        with:
+          fetch-depth: 1
 
       - name: Validate wiki publishing configuration
         run: |

--- a/.github/workflows/cleanup_cache.yml
+++ b/.github/workflows/cleanup_cache.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
+        with:
+          fetch-depth: 1
 
       - name: Cleanup
         run: |

--- a/.github/workflows/pr_report.yml
+++ b/.github/workflows/pr_report.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
+        with:
+          fetch-depth: 1
 
       - name: Get today's date
         id: date

--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
+        with:
+          fetch-depth: 1
 
       - name: Validate wiki publishing configuration
         run: |

--- a/.github/workflows/verify_newproject_script.yml
+++ b/.github/workflows/verify_newproject_script.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
+      with:
+        fetch-depth: 1
 
     - name: Copy mise config
       run: cp template/.mise.toml .mise.toml


### PR DESCRIPTION
- Close #668 

## What happened 👀

- Check each workflow and update checkout `fetch-depth` to the appropriate value.

## Insight 📝

N/A

## Proof Of Work 📹

- `.cicdtemplate/github/self-hosted-workflows/`

| Workflow | Before (fetch-depth) | After (fetch-depth) | Reason |
|--------|--------|--------|--------|
| deploy_app_store.yml | 0 | 1 | Only need to fetch the latest commit |
| deploy_production_firebase.yml | 0 | 1 | Only need to fetch the latest commit |
| deploy_staging_firebase.yml | 0 | 1 | Only need to fetch the latest commit |
| publish_docs_to_wiki.yml | N/A | 1 |  Explicitly set the fetch-depth, the behavior is unchanged |

- `.cicdtemplate/github/workflows/`

| Workflow | Before (fetch-depth) | After (fetch-depth) | Reason |
|--------|--------|--------|--------|
| add_device_profile.yml | 0 | 1 | Fastlane match only needs to fetch the latest commit |
| bump_version.yml | N/A | 1 | N/A |
| create_release_pull_request.yml | N/A | 1 | Explicitly set the fetch-depth, the behavior is unchanged |
| deploy_app_store.yml | 0 | 1 | Only need to fetch the latest commit |
| deploy_dev_firebase.yml | 0 | 1 | Only need to fetch the latest commit |
| deploy_production_firebase.yml | 0 | 1 | Only need to fetch the latest commit |
| publish_docs_to_wiki.yml | N/A | 1 |  Explicitly set the fetch-depth, the behavior is unchanged |

- `.github/workflows`

| Workflow | Before (fetch-depth) | After (fetch-depth) | Reason |
|--------|--------|--------|--------|
| cleanup_cache.yml | N/A | 1 |  Explicitly set the fetch-depth, the behavior is unchanged |
| pr_report.yml | N/A | 1 |  Explicitly set the fetch-depth, the behavior is unchanged |
| publish_docs_to_wiki.yml | N/A | 1 | Explicitly set the fetch-depth, the behavior is unchanged |
| verify_newproject_script.yml | N/A | 1 | Explicitly set the fetch-depth, the behavior is unchanged |


- Workflow run successfully after shallowed the checkout depth
<img width="1668" height="788" alt="Screenshot 2026-04-10 at 11 04 51" src="https://github.com/user-attachments/assets/817584fb-d81d-4822-a881-56d89d371ce5" />


