### PR TITLE
[#674] Update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,19 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.cicdtemplate/.github/workflows"
+      - "/.cicdtemplate/.github/self-hosted-workflows"
+      - "/.github/actions/setup-ci-environment"
+      - "/.github/actions/swiftlint"
+      - "/.cicdtemplate/.github/actions/build-and-deploy-firebase"
+      - "/.cicdtemplate/.github/actions/setup-ci-environment"
+      - "/.cicdtemplate/.github/actions/swiftlint"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "github-actions"
-    directory: "/.cicdtemplate"
-    schedule:
-      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions:
+        applies-to: version-updates
+        group-by: dependency-name

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+      time: "02:00" # 9 AM UTC+7
     groups:
       github-actions:
         applies-to: version-updates


### PR DESCRIPTION
- Close #674 

## What happened 👀

- Single `github-actions` entry with a `directories` list instead of two entries with directory: "/" and directory: "/.cicdtemplate".
- Update paths: repo root (/), .cicdtemplate workflows + self-hosted-workflows, and five composite action folders (action.yml locations).
 - Update schedule: still weekly, plus `day: monday`.
 - Group with `group-by: dependency-name` and `applies-to: version-updates` so the same action bumps once across those directories for routine updates.

## Insight 📝

N/A
## Proof Of Work 📹

Check dependencies update PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated automated dependency update scanning to cover more paths and removed duplicate entries.
  * Standardized update schedule to weekly (Mondays at 02:00) and organized version-update pull requests into groups by dependency name for clearer, more predictable maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->