### PR TITLE
[#685] Reduce GitHub Actions runtime and cost

### DIFF
--- a/.github/workflows/cleanup_cache.yml
+++ b/.github/workflows/cleanup_cache.yml
@@ -4,15 +4,14 @@ on:
     types:
       - closed
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   cleanup_cache:
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
-        with:
-          fetch-depth: 1
-
       - name: Cleanup
         run: |
           gh extension install actions/gh-actions-cache

--- a/.github/workflows/cleanup_cache.yml
+++ b/.github/workflows/cleanup_cache.yml
@@ -4,14 +4,15 @@ on:
     types:
       - closed
 
-permissions:
-  actions: write
-  contents: read
-
 jobs:
   cleanup_cache:
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
     steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
+        with:
+          fetch-depth: 1
+
       - name: Cleanup
         run: |
           gh extension install actions/gh-actions-cache

--- a/.github/workflows/pr_report.yml
+++ b/.github/workflows/pr_report.yml
@@ -3,6 +3,12 @@ name: PR Report
 on:
   workflow_dispatch:
   push:
+    paths-ignore:
+      - README.md
+      - AGENTS.md
+      - .github/wiki/**
+      - template/README.md
+      - template/AGENTS.md
   schedule:
     - cron: '0 2 * * 1-5' # weekdays at 9 AM ICT (UTC+7)
 

--- a/.github/workflows/test_upload_build_staging_to_firebase.yml
+++ b/.github/workflows/test_upload_build_staging_to_firebase.yml
@@ -9,6 +9,12 @@ name: Test Upload Staging Build to Firebase
 on:
   push:
     branches: [ develop ]
+    paths-ignore:
+      - README.md
+      - AGENTS.md
+      - .github/wiki/**
+      - template/README.md
+      - template/AGENTS.md
   workflow_dispatch:
 
 concurrency:
@@ -23,7 +29,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     - uses: ./.github/actions/swiftlint
 
   build:
@@ -34,6 +40,14 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
         fetch-depth: 0
+
+    - name: Cache iOSTemplateMaker Build
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # actions/cache@v5.0.4
+      with:
+        path: scripts/iOSTemplateMaker/.build
+        key: ${{ runner.os }}-iostemplatemaker-${{ hashFiles('scripts/iOSTemplateMaker/Package.swift', 'scripts/iOSTemplateMaker/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-iostemplatemaker-
 
     - name: Create Release Note
       run: |

--- a/.github/workflows/test_upload_build_to_test_flight.yml
+++ b/.github/workflows/test_upload_build_to_test_flight.yml
@@ -38,14 +38,13 @@ jobs:
     - name: Setup CI environment
       uses: ./.github/actions/setup-ci-environment
 
-    - name: Cache SPM Packages
+    - name: Cache iOSTemplateMaker Build
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # actions/cache@v5.0.4
-      id: spmCache
       with:
-        path: .build
-        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+        path: scripts/iOSTemplateMaker/.build
+        key: ${{ runner.os }}-iostemplatemaker-${{ hashFiles('scripts/iOSTemplateMaker/Package.swift', 'scripts/iOSTemplateMaker/Package.resolved') }}
         restore-keys: |
-          ${{ runner.os }}-spm-
+          ${{ runner.os }}-iostemplatemaker-
 
     - name: Start Install Script for Template App
       run: swift run --package-path scripts/iOSTemplateMaker iOSTemplateMaker make --bundle-id-production co.nimblehq.ios.templates --bundle-id-staging co.nimblehq.ios.templates.staging --project-name TemplateApp

--- a/.github/workflows/test_upload_dev_build_to_firebase.yml
+++ b/.github/workflows/test_upload_dev_build_to_firebase.yml
@@ -10,6 +10,12 @@ on:
   push:
     branches:
       - develop
+    paths-ignore:
+      - README.md
+      - AGENTS.md
+      - .github/wiki/**
+      - template/README.md
+      - template/AGENTS.md
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,6 +33,14 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
         fetch-depth: 0
+
+    - name: Cache iOSTemplateMaker Build
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # actions/cache@v5.0.4
+      with:
+        path: scripts/iOSTemplateMaker/.build
+        key: ${{ runner.os }}-iostemplatemaker-${{ hashFiles('scripts/iOSTemplateMaker/Package.swift', 'scripts/iOSTemplateMaker/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-iostemplatemaker-
 
     - name: Create Release Note
       run: |

--- a/.github/workflows/verify_newproject_script.yml
+++ b/.github/workflows/verify_newproject_script.yml
@@ -1,7 +1,13 @@
 name: Verify New Project Script
 
 on:
-  pull_request
+  pull_request:
+    paths-ignore:
+      - README.md
+      - AGENTS.md
+      - .github/wiki/**
+      - template/README.md
+      - template/AGENTS.md
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -27,6 +33,14 @@ jobs:
       with:
         bundler-cache: "false"
         run-bundle-install: "false"
+
+    - name: Cache iOSTemplateMaker Build
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # actions/cache@v5.0.4
+      with:
+        path: scripts/iOSTemplateMaker/.build
+        key: ${{ runner.os }}-iostemplatemaker-${{ hashFiles('scripts/iOSTemplateMaker/Package.swift', 'scripts/iOSTemplateMaker/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-iostemplatemaker-
 
     - name: Run iOSTemplateMaker
       run: |


### PR DESCRIPTION
Closes #685

## What happened 👀
- Added path filters so docs-only changes do not trigger expensive CI jobs.
- Cached `scripts/iOSTemplateMaker/.build` to reuse generator build artifacts.
- Reduced checkout depth where full history is not needed.

## Insight 📝

This lowers GitHub Actions runtime and cost without changing release behavior. I kept `cleanup_cache` on the self-hosted Mac runner because that workflow belongs there.

## Proof Of Work 📹

- YAML validated locally
- `git diff --check` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflows to improve build efficiency and reduce unnecessary workflow executions for documentation-only changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->