### PR TITLE
[#316] Use CI build numbers for Fastlane lanes

### DIFF
--- a/.github/wiki/Bitrise.md
+++ b/.github/wiki/Bitrise.md
@@ -47,6 +47,8 @@ All four workflows have their own variables:
 
 *Depending on which workflow, the value of those variables may differ from other workflows.*
 
+The Fastlane build lanes use Bitrise's `BITRISE_BUILD_NUMBER` when setting the app build number.
+
 ### Secrets
 
 - MATCH_PASSWORD

--- a/.github/wiki/CodeMagic.md
+++ b/.github/wiki/CodeMagic.md
@@ -42,6 +42,8 @@ Out of the box, the CodeMagic Template has the following workflows and steps:
 | BUMP_APP_STORE_BUILD_NUMBER | The boolean flag to determine if the Fastlane should bump the app store build number. |
 | GITHUB_TOKEN                | The token of GitHub to run Danger.                           |
 
+The Fastlane build lanes use Codemagic's project-level build counter (`PROJECT_BUILD_NUMBER`) when setting the app build number.
+
 ## Installation
 
 1. Follow the setup instruction in [`README.md`](https://github.com/nimblehq/ios-templates#readme).

--- a/.github/wiki/Fastlane.md
+++ b/.github/wiki/Fastlane.md
@@ -146,3 +146,5 @@ The `Test` helps build and test the application.
 ### Version.swift
 
 The `Version` manages the application's build number and version number.
+
+When the app is built on CI, the Fastlane lanes prefer the CI provider's build counter instead of counting git commits. The template falls back to the commit count for local runs or when the CI build number is unavailable.

--- a/.github/wiki/Github-Actions.md
+++ b/.github/wiki/Github-Actions.md
@@ -44,6 +44,8 @@ There are currently 4 workflows:
 5. Build archive version of the specified scheme.
 6. Deploy to Firebase Distribution, TestFlight, or App Store.
 
+The deploy workflows use `GITHUB_RUN_NUMBER` as the build counter, so they only need a shallow checkout instead of the full git history.
+
 # Installation
 
 ## Environment Secrets

--- a/.github/workflows/test_upload_build_staging_to_firebase.yml
+++ b/.github/workflows/test_upload_build_staging_to_firebase.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Checkout Repo
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
-        fetch-depth: 0
+        fetch-depth: 1
 
     - name: Cache iOSTemplateMaker Build
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # actions/cache@v5.0.4
@@ -81,6 +81,7 @@ jobs:
     - name: Setup CI environment
       uses: ./.github/actions/setup-ci-environment
 
+    # Run `make-test-firebase` before `make` — `make` removes `scripts/` when promoting the template.
     - name: Configure Template App for Firebase upload
       run: swift run --package-path scripts/iOSTemplateMaker iOSTemplateMaker make-test-firebase
       env:

--- a/.github/workflows/test_upload_build_to_test_flight.yml
+++ b/.github/workflows/test_upload_build_to_test_flight.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Checkout Repo
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
-        fetch-depth: 0
+        fetch-depth: 1
 
     - name: Install SSH key
       uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # webfactory/ssh-agent@v0.10.0
@@ -46,9 +46,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-iostemplatemaker-
 
-    - name: Start Install Script for Template App
-      run: swift run --package-path scripts/iOSTemplateMaker iOSTemplateMaker make --bundle-id-production co.nimblehq.ios.templates --bundle-id-staging co.nimblehq.ios.templates.staging --project-name TemplateApp
-
+    # Run `make-test-test-flight` before `make` — `make` removes `scripts/` when promoting the template.
     - name: Start Setup Script for Template App TestFlight Upload
       run: swift run --package-path scripts/iOSTemplateMaker iOSTemplateMaker make-test-test-flight
       env:
@@ -56,6 +54,9 @@ jobs:
         API_KEY_ID: ${{ secrets.API_KEY_ID }}
         ISSUER_ID: ${{ secrets.ISSUER_ID }}
         TEAM_ID: ${{ secrets.TEAM_ID }}
+
+    - name: Start Install Script for Template App
+      run: swift run --package-path scripts/iOSTemplateMaker iOSTemplateMaker make --bundle-id-production co.nimblehq.ios.templates --bundle-id-staging co.nimblehq.ios.templates.staging --project-name TemplateApp
 
     - name: Set Up Test Project for App Store
       run: bundle exec fastlane setUpTestProject

--- a/.github/workflows/test_upload_dev_build_to_firebase.yml
+++ b/.github/workflows/test_upload_dev_build_to_firebase.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Checkout Repo
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:
-        fetch-depth: 0
+        fetch-depth: 1
 
     - name: Cache iOSTemplateMaker Build
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # actions/cache@v5.0.4
@@ -70,6 +70,7 @@ jobs:
     - name: Setup CI environment
       uses: ./.github/actions/setup-ci-environment
 
+    # Run `make-test-firebase` before `make` — `make` removes `scripts/` when promoting the template.
     - name: Configure Template App for Firebase upload
       run: swift run --package-path scripts/iOSTemplateMaker iOSTemplateMaker make-test-firebase
       env:

--- a/scripts/iOSTemplateMaker/Sources/iOSTemplateMaker/SetUpiOSProject.swift
+++ b/scripts/iOSTemplateMaker/Sources/iOSTemplateMaker/SetUpiOSProject.swift
@@ -134,12 +134,17 @@ class SetUpIOSProject {
         }
         
         if bundleIdDev.isEmpty {
-            tryMoveDown()
-            bundleIdDev = ask(
-                "Which is the bundle ID for the dev environment?",
-                note: "Ex: com.example.project.dev",
-                onValidate: validatePackageName
-            )
+            if isCI {
+                bundleIdDev = inferDevBundleId()
+                write("Auto-filled dev bundle ID for CI: \(bundleIdDev)", style: .warning)
+            } else {
+                tryMoveDown()
+                bundleIdDev = ask(
+                    "Which is the bundle ID for the dev environment?",
+                    note: "Ex: com.example.project.dev",
+                    onValidate: validatePackageName
+                )
+            }
         }
 
         if projectName.isEmpty {
@@ -277,5 +282,17 @@ class SetUpIOSProject {
         let valid = version ~= versionRegex
 
         return valid ? nil : "Please pick a valid version with pattern {x.y}"
+    }
+
+    private func inferDevBundleId() -> String {
+        if bundleIdStaging.hasSuffix(".staging") {
+            return String(bundleIdStaging.dropLast(".staging".count)) + ".dev"
+        }
+
+        if !bundleIdProduction.isEmpty {
+            return "\(bundleIdProduction).dev"
+        }
+
+        return "\(bundleIdStaging).dev"
     }
 }

--- a/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Modules/Landing/LandingView.swift
+++ b/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Modules/Landing/LandingView.swift
@@ -5,11 +5,7 @@ struct LandingView: View {
 
     @StateObject private var viewModel: LandingViewModel
 
-    init() {
-        _viewModel = StateObject(wrappedValue: LandingViewModel())
-    }
-
-    init(viewModel: LandingViewModel) {
+    init(viewModel: LandingViewModel = LandingViewModel()) {
         _viewModel = StateObject(wrappedValue: viewModel)
     }
 

--- a/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Modules/Landing/LandingViewModel.swift
+++ b/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Modules/Landing/LandingViewModel.swift
@@ -54,7 +54,7 @@ final class LandingViewModel: ObservableObject {
 
 private struct DemoTokenSet: TokenSetProtocol {
 
-    let accessToken = "demo-access-token"
-    let refreshToken = "demo-refresh-token"
-    let expiresAt = Calendar.current.date(byAdding: .day, value: 30, to: Date())
+    var accessToken: String { "demo-access-token" }
+    var refreshToken: String { "demo-refresh-token" }
+    var expiresAt: Date? { Date().addingTimeInterval(60 * 60 * 24 * 30) }
 }

--- a/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Modules/Landing/LandingViewModel.swift
+++ b/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Modules/Landing/LandingViewModel.swift
@@ -54,7 +54,7 @@ final class LandingViewModel: ObservableObject {
 
 private struct DemoTokenSet: TokenSetProtocol {
 
-    var accessToken: String { "demo-access-token" }
-    var refreshToken: String { "demo-refresh-token" }
-    var expiresAt: Date? { Date().addingTimeInterval(60 * 60 * 24 * 30) }
+    let accessToken = "demo-access-token"
+    let refreshToken = "demo-refresh-token"
+    let expiresAt: Date? = Date().addingTimeInterval(60 * 60 * 24 * 30)
 }

--- a/template/fastlane/Fastfile.swift
+++ b/template/fastlane/Fastfile.swift
@@ -239,10 +239,22 @@ class Fastfile: LaneFile {
         )
     }
 
-    private func bumpBuild(buildNumber: Int = numberOfCommits()) {
-        desc("Set build number with number of commits")
+    private func bumpBuild(buildNumber: Int? = nil) {
+        let ciBuildNumber = Build.ciBuildNumber
+        let resolvedBuildNumber = buildNumber ?? ciBuildNumber ?? numberOfCommits()
+        let buildSource: String
+
+        if buildNumber != nil {
+            buildSource = "provided build number"
+        } else if ciBuildNumber != nil {
+            buildSource = "CI build number"
+        } else {
+            buildSource = "number of commits"
+        }
+
+        desc("Set build number with \(buildSource)")
         incrementBuildNumber(
-            buildNumber: .userDefined(String(buildNumber)),
+            buildNumber: .userDefined(String(resolvedBuildNumber)),
             xcodeproj: .userDefined(Constant.projectPath)
         )
     }

--- a/template/fastlane/Helpers/Build.swift
+++ b/template/fastlane/Helpers/Build.swift
@@ -20,6 +20,20 @@ enum Build {
         build(environment: .production, type: .appStore)
     }
 
+    static var ciBuildNumber: Int? {
+        switch Constant.platform {
+        case .gitHubActions:
+            return EnvironmentParser.integer(key: "GITHUB_RUN_NUMBER")
+        case .bitrise:
+            return EnvironmentParser.integer(key: "BITRISE_BUILD_NUMBER")
+        case .codeMagic:
+            return EnvironmentParser.integer(key: "PROJECT_BUILD_NUMBER")
+                ?? EnvironmentParser.integer(key: "BUILD_NUMBER")
+        default:
+            return nil
+        }
+    }
+
     // MARK: Save the build context
 
     static func saveBuildContextToCI() {
@@ -79,8 +93,7 @@ enum Build {
             exportMethod: .userDefined(type.value),
             exportOptions: .userDefined(exportOptions),
             buildPath: .userDefined(Constant.buildPath),
-            derivedDataPath: .userDefined(Constant.derivedDataPath),
-            xcargs: .userDefined("-verbose")
+            derivedDataPath: .userDefined(Constant.derivedDataPath)
         )
         
         echo(message: "✅ Build process completed")

--- a/template/fastlane/Helpers/EnvironmentParser.swift
+++ b/template/fastlane/Helpers/EnvironmentParser.swift
@@ -14,6 +14,10 @@ enum EnvironmentParser {
         string(key: key) == "true"
     }
 
+    static func integer(key: String) -> Int? {
+        Int(string(key: key))
+    }
+
     static func string(key: String) -> String {
         environmentVariable(get: .userDefined(key))
     }


### PR DESCRIPTION
- Close #316 

## What happened 👀

This PR resolves [#316](https://github.com/nimblehq/ios-templates/issues/316) by using CI-provided build numbers in Fastlane and removing the dependency on full git history in CI.

### Changes
- Fastlane now prefers CI build counters when setting build number:
  - GitHub Actions: `GITHUB_RUN_NUMBER`
  - Bitrise: `BITRISE_BUILD_NUMBER`
  - CodeMagic: `PROJECT_BUILD_NUMBER` (fallback `BUILD_NUMBER`)
- Fallback to commit count remains for local/non-CI runs.
- Updated deploy/test-upload GitHub workflows to use shallow checkout (`fetch-depth: 1`).
- Added docs updates in wiki to explain the new CI build-number behavior.

### Follow-up fixes from CI validation
- Fixed CI template generation crash by auto-filling `bundleIdDev` in CI when not provided (non-interactive-safe).
- Fixed `test_upload_build_to_test_flight.yml` step order:
  - run `make-test-test-flight` **before** `make` (since `make` promotes template and removes `scripts/`).
- Added comments in all test-upload workflows to keep this step order clear.
- Stabilized archive/build flow:
  - simplified `LandingView` `@StateObject` initialization
  - adjusted demo token implementation for safer Swift 6 behavior
  - removed verbose `xcargs` in fastlane build helper to reduce noisy output and improve runner stability
  - kept CI build number resolution behavior intact

## Insight 📝

Using CI-native counters is the most reliable approach in CI:
- predictable build numbers per run
- avoids duplicate build numbers when rebuilding the same commit
- no need for full git history checkout

We kept local fallback to commit count to preserve existing local behavior.

### How to test
1. Run Fastlane lane without CI vars → fallback to commit count.
2. Run with CI vars (`GITHUB_RUN_NUMBER` / `BITRISE_BUILD_NUMBER` / `PROJECT_BUILD_NUMBER`) → lane uses CI build number.
3. Trigger test-upload workflows:
   - confirm setup subcommand runs before `make`
   - confirm workflow succeeds with `fetch-depth: 1`
4. In TestFlight/App Store upload lane logs, verify:
   - `latest_testflight_build_number`
   - `increment_build_number`
   - lane context includes expected `BUILD_NUMBER`

## Proof Of Work 📹

Successful [Test Upload Build to TestFlight](https://github.com/nimblehq/ios-templates/actions/runs/24436985989) run confirms:
- `Start Setup Script for Template App TestFlight Upload` ✅
- `Start Install Script for Template App` ✅

<img width="1259" height="494" alt="Screenshot 2026-04-15 at 13 14 51" src="https://github.com/user-attachments/assets/5b273543-406d-4bae-b98c-d4ac442d7686" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI integration guidance for build numbering across GitHub Actions, Bitrise, and CodeMagic.

* **Bug Fixes**
  * Fixed automatic dev bundle ID inference in CI environments, eliminating manual prompts.

* **Chores**
  * Optimized Git checkout depth in workflows for faster CI operations.
  * Enhanced Firebase upload workflow configuration and step sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->