### PR TITLE
[#690] Add Swift Concurrency Skill

### DIFF
--- a/skills/swift-concurrency/SKILL.md
+++ b/skills/swift-concurrency/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: swift6-concurrency
+description: >
+  Write, review, or fix Swift 6 concurrency code using actors, Sendable, structured concurrency,
+  and the strict data-race-safety model. Use when working with async/await, actors, data race
+  compiler errors, Sendable conformance, TaskGroup, AsyncSequence, or migrating Swift 5 code
+  to Swift 6 strict concurrency. Triggers on: "actor", "Sendable", "data race", "MainActor",
+  "async let", "TaskGroup", "AsyncStream", "concurrency warning", "strict concurrency",
+  "Swift 6 concurrency", "nonisolated", "Mutex".
+---
+
+# Swift 6 Concurrency
+
+## Overview
+
+Write, review, and fix Swift 6 concurrency code in this iOS project. Swift 6 enforces complete data race safety at compile time — every piece of mutable state that crosses a concurrency domain boundary must be protected by actors, `Sendable` conformance, or `Mutex`. This skill applies to all modules: App, Data, Domain, and Model.
+
+## Agent Behavior Contract
+
+1. **Never suppress concurrency errors with `nonisolated(unsafe)` without explicit user approval.** Investigate and fix the isolation root cause first.
+2. **In async contexts, `actor` is the default for shared mutable state.** In synchronous contexts, prefer refactoring to async and using an `actor`; reach for `Mutex` (from `Synchronization`) only when async refactoring is not feasible, the critical section has no `await`, or fine-grained locking over a single value is needed.
+3. **Use `@MainActor` for all UI-bound state.** Apply it to `ObservableObject` view models and `@Observable` types that drive the view hierarchy.
+4. **Prefer structured concurrency** (`async let`, `TaskGroup`) over unstructured `Task { }`. Attach work to a parent task whenever possible.
+5. **Mark types `Sendable` explicitly** when they cross isolation boundaries. Prefer value types (`struct`, `enum`) — they are implicitly `Sendable` when all stored properties are `Sendable`.
+6. **Propagate task cancellation.** Check `Task.isCancelled` or call `try Task.checkCancellation()` inside loops or long-running operations.
+7. **Avoid `@unchecked Sendable`** unless integrating a third-party type that is thread-safe but lacks annotation. Always add a comment explaining why it is safe.
+8. **Use `@preconcurrency import`** when adopting a framework not yet fully annotated for Swift 6, to suppress false-positive warnings at the boundary.
+9. **No `DispatchQueue` in new Swift 6 code.** Use `actor` for shared mutable state. `Mutex` is acceptable for short synchronous critical sections, but never as a default replacement for actors.
+10. **Never call `MainActor.assumeIsolated`** outside of truly non-async contexts (e.g., UIKit delegate callbacks). In async code, just annotate or `await MainActor.run { }`.
+
+## Quick Triage
+
+Before writing or reviewing concurrency code, clarify:
+
+1. **Which isolation domain?** Main actor (UI), custom actor (domain/data service), or nonisolated?
+2. **What mutability pattern?** Value type passed by copy, reference type shared by reference, or actor-protected state?
+3. **Structured or unstructured?** Is there a parent `async` context to attach the child task to?
+4. **Concurrency mode?** Check `SWIFT_STRICT_CONCURRENCY` in build settings — `complete` is Swift 6 mode.
+
+## Canonical Patterns
+
+### Actor protecting shared mutable state
+
+```swift
+actor TokenStore {
+
+    private var accessToken: String?
+    private var refreshToken: String?
+
+    func store(access: String, refresh: String) {
+        accessToken = access
+        refreshToken = refresh
+    }
+
+    func retrieveAccessToken() -> String? {
+        accessToken
+    }
+}
+```
+
+### `@MainActor` view model
+
+```swift
+@MainActor
+final class HomeViewModel: ObservableObject {
+
+    @Published private(set) var items: [HomeItem] = []
+    @Published private(set) var isLoading = false
+
+    private let repository: any HomeRepository
+
+    init(repository: some HomeRepository) {
+        self.repository = repository
+    }
+
+    func load() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            items = try await repository.fetchItems()
+        } catch {
+            items = []
+        }
+    }
+}
+```
+
+### Structured concurrency with `async let`
+
+```swift
+func loadDashboard() async throws -> Dashboard {
+    async let user = userRepository.fetchCurrentUser()
+    async let orders = orderRepository.fetchRecentOrders()
+    async let banners = bannerRepository.fetchActiveBanners()
+
+    return try await Dashboard(
+        user: user,
+        orders: orders,
+        banners: banners
+    )
+}
+```
+
+### `TaskGroup` for dynamic fan-out
+
+```swift
+func fetchDetails(for ids: [String]) async throws -> [ItemDetail] {
+    try await withThrowingTaskGroup(of: ItemDetail.self) { group in
+        for id in ids {
+            group.addTask {
+                try await self.repository.fetchDetail(id: id)
+            }
+        }
+        return try await group.reduce(into: []) { $0.append($1) }
+    }
+}
+```
+
+### `Mutex` for synchronous shared state (no async)
+
+```swift
+import Synchronization
+
+final class RequestCounter: Sendable {
+
+    private let _count = Mutex(0)
+
+    func increment() {
+        _count.withLock { $0 += 1 }
+    }
+
+    var count: Int {
+        _count.withLock { $0 }
+    }
+}
+```
+
+## Routing to References
+
+Load the appropriate reference file based on the task:
+
+| Task | Reference |
+|------|-----------|
+| Actor design, actor isolation, `nonisolated`, global actors | `references/actors.md` |
+| `Sendable`, `@Sendable` closures, crossing isolation boundaries | `references/sendability.md` |
+| `async let`, `Task`, `TaskGroup`, task cancellation | `references/structured-concurrency.md` |
+| `AsyncSequence`, `AsyncStream`, `for await` loops | `references/async-sequences.md` |
+
+## Verification Checklist
+
+Before finishing, confirm:
+
+- [ ] All mutable state shared across concurrency domains is actor-isolated or `Sendable`
+- [ ] `@MainActor` is applied to all `ObservableObject` / `@Observable` view models
+- [ ] `async let` or `TaskGroup` used instead of a chain of sequential `await` calls where parallelism is possible
+- [ ] No `Task.detached` unless genuinely required — if used, explain why in a comment
+- [ ] Long loops call `try Task.checkCancellation()` at each iteration
+- [ ] `Mutex` only used when the critical section is short, purely synchronous, and has no `await` — actor is the default otherwise
+- [ ] `AsyncStream` / `AsyncThrowingStream` continuations call `.finish()` in all exit paths including errors
+- [ ] No `DispatchQueue` in new code
+- [ ] `nonisolated(unsafe)` absent (or signed off by the user with a safety comment)

--- a/skills/swift-concurrency/SKILL.md
+++ b/skills/swift-concurrency/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: swift6-concurrency
+name: swift-concurrency
 description: >
   Write, review, or fix Swift 6 concurrency code using actors, Sendable, structured concurrency,
   and the strict data-race-safety model. Use when working with async/await, actors, data race

--- a/skills/swift-concurrency/references/actors.md
+++ b/skills/swift-concurrency/references/actors.md
@@ -1,0 +1,356 @@
+# Actors
+
+## When to use this reference
+
+Use when needing to protect class-based mutable state from concurrent access, designing actor types, resolving actor isolation errors, working with global actors (`@MainActor`), or making protocol conformances work across isolation domains.
+
+## What actors provide
+
+An `actor` is a reference type that serializes access to its stored properties. The compiler guarantees:
+
+- All reads and writes to actor-isolated state happen sequentially.
+- Callers outside the actor must `await` to access isolated members.
+- No two tasks can be inside the actor concurrently.
+
+## Basic actor
+
+```swift
+actor SessionManager {
+
+    private var isAuthenticated = false
+    private(set) var userId: String?
+
+    func logIn(userId: String) {
+        isAuthenticated = true
+        currentUserId = userId
+    }
+
+    func logOut() {
+        isAuthenticated = false
+        currentUserId = nil
+    }
+}
+```
+
+### Callers outside the actor:
+
+```swift
+let manager = SessionManager()
+await manager.logIn(userId: "abc123")
+print(await manager.userId) // Must await reads too
+```
+
+Always use await when accessing actor properties/methods—you don't know if another task is inside.
+
+### Callers inside the actor (no `await` needed):
+
+```swift
+actor SessionManager {
+
+    func reset() {
+        logOut()           // No await — same isolation domain
+    }
+}
+```
+
+## Actors vs Classes
+
+### Similarities
+
+- Reference types (copies share same instance)
+- Can have properties, methods, initializers
+- Can conform to protocols
+
+### Differences
+
+- **No inheritance** (except `NSObject` for Objective-C interop)
+- **Automatic isolation** (no manual locks needed)
+- **Implicit Sendable** conformance
+
+```swift
+// ❌ Can't inherit from actors
+actor Base {}
+actor Child: Base {} // Error
+
+// ✅ NSObject exception
+actor Example: NSObject {} // OK for Objective-C
+```
+
+## `nonisolated` members
+
+Use `nonisolated` for members that do not touch actor state — they can be called without `await`.
+
+```swift
+actor AnalyticsClient {
+
+    private var eventLog: [String] = []
+
+    nonisolated let serviceID: String   // Stored constant — safe to access without await
+
+    init(serviceID: String) {
+        self.serviceID = serviceID
+    }
+
+    func track(event: String) {
+        eventLog.append(event)
+    }
+}
+
+// Callers can read serviceID synchronously:
+let id = analyticsClient.serviceID
+```
+
+Rules for `nonisolated`:
+- Safe on `let` stored properties (immutable — no data race possible).
+- Safe on computed properties and methods that only read immutable or `Sendable` values.
+- **Never** apply `nonisolated` to a `var` stored property — the compiler will reject it.
+
+## `nonisolated(unsafe)` — last resort
+
+`nonisolated(unsafe)` opts a stored property out of actor isolation checking. Only use this as a compatibility escape hatch for types you cannot change, and always justify it:
+
+```swift
+actor LegacyBridge {
+
+    // Safe: SDWebImageManager is internally thread-safe via its own locks.
+    nonisolated(unsafe) let imageManager = SDWebImageManager.shared
+}
+```
+
+If you find yourself reaching for `nonisolated(unsafe)` on your own types, redesign the isolation instead.
+
+## Global actors
+
+A global actor is a singleton actor that can be applied to types, methods, and properties with an attribute.
+
+### `@MainActor`
+
+The built-in global actor that represents the main thread. Apply it to anything that must run on the main thread.
+
+```swift
+@MainActor
+final class CartViewModel: ObservableObject {
+
+    @Published private(set) var itemCount = 0
+}
+```
+
+```swift
+@MainActor
+func updateBadge(count: Int) {
+    tabBarItem.badgeValue = count > 0 ? "\(count)" : nil
+}
+```
+
+Crossing into `@MainActor` from a non-isolated context:
+
+```swift
+func backgroundWork() async {
+    let result = await heavyComputation()
+    await MainActor.run {
+        label.text = result   // Now on main thread
+    }
+}
+```
+
+### `@MainActor` Best Practices
+
+### When to use
+
+UI-related code that must run on main thread:
+
+```swift
+@MainActor
+final class ContentViewModel: ObservableObject {
+    @Published var items: [Item] = []
+}
+```
+
+### Replacing DispatchQueue.main
+
+```swift
+// Old way
+DispatchQueue.main.async {
+    // Update UI
+}
+
+// Modern way
+await MainActor.run {
+    // Update UI
+}
+
+// Better: Use attribute
+@MainActor
+func updateUI() {
+    // Automatically on main thread
+}
+
+### Custom global actor
+
+Define a custom global actor when you want a domain-wide shared executor (e.g., a database queue).
+
+```swift
+@globalActor
+actor DatabaseActor {
+
+    static let shared = DatabaseActor()
+}
+
+@DatabaseActor
+final class DatabaseService {
+
+    func query(_ sql: String) -> [Row] { /* ... */ }
+}
+```
+
+Use sparingly. Prefer injecting an actor instance over global actors for testability.
+
+## Actor protocol conformance
+
+When a protocol method must run on an actor, annotate the protocol requirement:
+
+```swift
+protocol DataRefreshable {
+
+    func refresh() async
+}
+
+actor DataService: DataRefreshable {
+
+    func refresh() async {
+        // actor-isolated — safe to mutate state here
+    }
+}
+```
+
+When conforming to a protocol from a `@MainActor` type:
+
+```swift
+protocol Refreshable {
+
+    @MainActor func refresh()
+}
+
+@MainActor
+final class HomeViewModel: Refreshable {
+
+    func refresh() { /* runs on main actor */ }
+}
+```
+
+If the protocol is unannotated and from a third-party framework, use `@preconcurrency` (see `references/migration.md`).
+
+## Actor reentrancy
+
+Actors are **reentrant** — while an `await` inside an actor is suspended, another caller can enter the actor and mutate state. Guard against this:
+
+```swift
+actor ImageCache {
+
+    private var cache: [URL: UIImage] = [:]
+    private var inflightRequests: Set<URL> = []
+
+    func image(for url: URL) async throws -> UIImage {
+        if let cached = cache[url] { return cached }
+
+        // Check before suspending
+        guard !inflightRequests.contains(url) else {
+            // Wait or return a placeholder — don't start a duplicate request
+            throw CacheError.requestInFlight
+        }
+
+        inflightRequests.insert(url)
+        defer { inflightRequests.remove(url) }
+
+        // Suspension point — another task may enter here
+        let image = try await downloadImage(from: url)
+
+        cache[url] = image
+        return image
+    }
+}
+```
+
+Pattern: re-check invariants after every `await` inside an actor.
+
+## Mutex: Alternative to Actors
+
+`Mutex` (from `Synchronization`, requires iOS 18+ / macOS 15+) provides synchronous locking without async/await overhead.
+
+```swift
+import Synchronization
+
+final class Counter: Sendable {
+
+    private let count = Mutex<Int>(0)
+
+    var currentCount: Int {
+        count.withLock { $0 }
+    }
+
+    func increment() {
+        count.withLock { $0 += 1 }
+    }
+}
+```
+
+`Mutex` also enables `Sendable` access to otherwise non-`Sendable` types:
+
+```swift
+final class TouchesCapturer: Sendable {
+
+    let path = Mutex<NSBezierPath>(NSBezierPath())
+
+    func storeTouch(_ point: NSPoint) {
+        path.withLock { $0.move(to: point) }
+    }
+}
+```
+
+### Mutex vs Actor
+
+| Feature | Mutex | Actor |
+| ------- | ----- | ----- |
+| Synchronous access | ✅ | ❌ (requires `await`) |
+| Async support | ❌ | ✅ |
+| Thread blocking | ✅ | ❌ (cooperative) |
+| Fine-grained locking | ✅ | ❌ (whole actor at a time) |
+| Legacy code integration | ✅ | ❌ |
+
+**Use `Mutex` when:**
+
+- Synchronous access is required (no `await` inside the critical section)
+- Integrating with legacy non-async APIs
+- Fine-grained locking over a single value is needed
+- Contention is low and the critical section is short
+
+**Use `actor` when:**
+
+- Working in an async context and can use `await`
+- Logical isolation of a domain or service is needed
+- The critical section may itself need to `await`
+
+### Decision tree
+
+```text
+Need thread-safe mutable state?
+├─ Async context?
+│  ├─ Single instance?       → actor
+│  ├─ Global/shared?         → global actor (@MainActor or custom)
+│  └─ UI-related?            → @MainActor
+│
+└─ Synchronous context?
+   ├─ Can refactor to async?  → actor (preferred)
+   ├─ Legacy code integration? → Mutex
+   └─ Fine-grained locking?   → Mutex
+```
+
+## Do / Don't
+
+- **Do** use actors for any reference type with mutable state accessed from multiple async contexts.
+- **Do** use `nonisolated` on `let` constants and pure functions to avoid unnecessary `await` at call sites.
+- **Do** re-check actor state after every `await` — reentrancy can change it.
+- **Do** use `@MainActor` for all view models, UI updates.
+- **Don't** put heavy synchronous work inside an actor — it blocks the actor's executor for other tasks.
+- **Don't** use `nonisolated(unsafe)` on your own types without a thread-safety justification comment.
+- **Don't** create a custom global actor when an injected actor instance would work — global actors are hard to test.

--- a/skills/swift-concurrency/references/actors.md
+++ b/skills/swift-concurrency/references/actors.md
@@ -22,12 +22,12 @@ actor SessionManager {
 
     func logIn(userId: String) {
         isAuthenticated = true
-        currentUserId = userId
+        self.userId = userId
     }
 
     func logOut() {
         isAuthenticated = false
-        currentUserId = nil
+        userId = nil
     }
 }
 ```
@@ -184,6 +184,7 @@ await MainActor.run {
 func updateUI() {
     // Automatically on main thread
 }
+```
 
 ### Custom global actor
 
@@ -237,8 +238,6 @@ final class HomeViewModel: Refreshable {
     func refresh() { /* runs on main actor */ }
 }
 ```
-
-If the protocol is unannotated and from a third-party framework, use `@preconcurrency` (see `references/migration.md`).
 
 ## Actor reentrancy
 

--- a/skills/swift-concurrency/references/actors.md
+++ b/skills/swift-concurrency/references/actors.md
@@ -10,7 +10,7 @@ An `actor` is a reference type that serializes access to its stored properties. 
 
 - All reads and writes to actor-isolated state happen sequentially.
 - Callers outside the actor must `await` to access isolated members.
-- No two tasks can be inside the actor concurrently.
+- Only one task executes actor-isolated code at any given time. Actors are **reentrant**: while a task is suspended at an `await` inside the actor, another task may enter and run — see [Actor reentrancy](#actor-reentrancy).
 
 ## Basic actor
 
@@ -102,7 +102,7 @@ let id = analyticsClient.serviceID
 
 Rules for `nonisolated`:
 - Safe on `let` stored properties (immutable — no data race possible).
-- Safe on computed properties and methods that only read immutable or `Sendable` values.
+- Safe on computed properties and methods that do not access actor-isolated stored state (they may only use nonisolated/static data or values that are local to the call). Note: a `Sendable` type alone is not enough — isolated state remains off-limits.
 - **Never** apply `nonisolated` to a `var` stored property — the compiler will reject it.
 
 ## `nonisolated(unsafe)` — last resort

--- a/skills/swift-concurrency/references/async-sequences.md
+++ b/skills/swift-concurrency/references/async-sequences.md
@@ -111,12 +111,14 @@ A stream that never calls `finish()` will stall its consumer indefinitely.
 
 ```swift
 AsyncThrowingStream { continuation in
-    do {
-        let data = try await fetch()
-        continuation.yield(data)
-        continuation.finish()          // ✓ Normal exit
-    } catch {
-        continuation.finish(throwing: error)   // ✓ Error exit
+    Task {
+        do {
+            let data = try await fetch()
+            continuation.yield(data)
+            continuation.finish()          // ✓ Normal exit
+        } catch {
+            continuation.finish(throwing: error)   // ✓ Error exit
+        }
     }
     // If there were an early return path, finish() must appear there too
 }
@@ -126,10 +128,12 @@ Use `defer` to guarantee finish:
 
 ```swift
 AsyncThrowingStream { continuation in
-    defer { continuation.finish() }
+    Task {
+        defer { continuation.finish() }
 
-    guard let data = try? await fetch() else { return }
-    continuation.yield(data)
+        guard let data = try? await fetch() else { return }
+        continuation.yield(data)
+    }
 }
 ```
 

--- a/skills/swift-concurrency/references/async-sequences.md
+++ b/skills/swift-concurrency/references/async-sequences.md
@@ -1,0 +1,211 @@
+# Async Sequences
+
+## When to use this reference
+
+Use when producing or consuming streams of values over time: live data feeds, event publishers, socket streams, progress updates, or converting callback/delegate APIs to async sequences.
+
+## `AsyncSequence` protocol
+
+`AsyncSequence` is the async counterpart to `Sequence`. Consumers iterate it with `for await`:
+
+```swift
+for await event in analyticsStream {
+    record(event)
+}
+```
+
+The loop suspends between elements and exits when the sequence is exhausted or the task is cancelled.
+
+## `AsyncStream` — continuation-based production
+
+Use `AsyncStream` to bridge a callback or delegate API into an async sequence. No `throws`.
+
+```swift
+func locationUpdates() -> AsyncStream<CLLocation> {
+    AsyncStream { continuation in
+        let monitor = LocationMonitor()
+
+        monitor.onUpdate = { location in
+            continuation.yield(location)
+        }
+
+        monitor.onStop = {
+            continuation.finish()
+        }
+
+        continuation.onTermination = { _ in
+            monitor.stop()   // Clean up when consumer cancels or stream ends
+        }
+
+        monitor.start()
+    }
+}
+```
+
+Consuming:
+
+```swift
+for await location in locationUpdates() {
+    updateMap(location)
+}
+```
+
+### Buffering strategy
+
+Control how the stream handles back-pressure:
+
+```swift
+AsyncStream(bufferingPolicy: .bufferingNewest(10)) { continuation in
+    // Keeps the 10 most recent values if the consumer is slow
+}
+```
+
+| Policy | Behaviour |
+|--------|-----------|
+| `.unbounded` | Buffer everything (default) — risk of unbounded memory growth |
+| `.bufferingNewest(n)` | Keep only the newest `n` pending values; drop older ones |
+| `.bufferingOldest(n)` | Keep only the oldest `n` pending values; drop newer ones |
+
+Prefer `.bufferingNewest` for UI event streams where only the latest value matters.
+
+## `AsyncThrowingStream` — failable streams
+
+Use when the producer can fail (e.g., a network stream that disconnects):
+
+```swift
+func fetchEventStream(url: URL) -> AsyncThrowingStream<ServerEvent, Error> {
+    AsyncThrowingStream { continuation in
+        let task = Task {
+            do {
+                let (bytes, _) = try await URLSession.shared.bytes(from: url)
+                for try await line in bytes.lines {
+                    let event = try JSONDecoder().decode(ServerEvent.self, from: Data(line.utf8))
+                    continuation.yield(event)
+                }
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+
+        continuation.onTermination = { _ in task.cancel() }
+    }
+}
+```
+
+Consuming:
+
+```swift
+do {
+    for try await event in fetchEventStream(url: streamURL) {
+        handle(event)
+    }
+} catch {
+    showError(error)
+}
+```
+
+## Always call `finish()` in all exit paths
+
+A stream that never calls `finish()` will stall its consumer indefinitely.
+
+```swift
+AsyncThrowingStream { continuation in
+    do {
+        let data = try await fetch()
+        continuation.yield(data)
+        continuation.finish()          // ✓ Normal exit
+    } catch {
+        continuation.finish(throwing: error)   // ✓ Error exit
+    }
+    // If there were an early return path, finish() must appear there too
+}
+```
+
+Use `defer` to guarantee finish:
+
+```swift
+AsyncThrowingStream { continuation in
+    defer { continuation.finish() }
+
+    guard let data = try? await fetch() else { return }
+    continuation.yield(data)
+}
+```
+
+## Transforming sequences
+
+Use the standard `AsyncSequence` operators:
+
+```swift
+let filtered = locationUpdates()
+    .filter { $0.horizontalAccuracy < 20 }
+
+let mapped = orderUpdates()
+    .map { OrderSummary(from: $0) }
+
+let first = try await statusUpdates().first(where: { $0 == .completed })
+```
+
+## Consuming with task cancellation
+
+The `for await` loop automatically stops when the enclosing task is cancelled and the sequence propagates cancellation. For sequences backed by `AsyncStream`, set `onTermination` to release resources:
+
+```swift
+continuation.onTermination = { @Sendable _ in
+    webSocketTask.cancel(with: .goingAway, reason: nil)
+}
+```
+
+The `@Sendable` annotation on the closure is required because `onTermination` can be called from any concurrency domain.
+
+## Converting `Combine` publishers to `AsyncSequence`
+
+Use `.values` on any `Publisher` to get an `AsyncPublisher`:
+
+```swift
+for await value in publisher.values {
+    handle(value)
+}
+```
+
+Prefer `AsyncStream` for new code. Use `.values` only when bridging an existing `Combine` pipeline.
+
+## Pattern: actor-owned stream producer
+
+Encapsulate stream production inside an actor to protect the continuation:
+
+```swift
+actor OrderTracker {
+
+    private var continuation: AsyncStream<OrderStatus>.Continuation?
+
+    lazy var statusStream: AsyncStream<OrderStatus> = {
+        AsyncStream { continuation in
+            self.continuation = continuation
+            continuation.onTermination = { @Sendable [weak self] _ in
+                Task { await self?.invalidate() }
+            }
+        }
+    }()
+
+    func update(status: OrderStatus) {
+        continuation?.yield(status)
+    }
+
+    func invalidate() {
+        continuation?.finish()
+        continuation = nil
+    }
+}
+```
+
+## Do / Don't
+
+- **Do** call `continuation.finish()` (or `finish(throwing:)`) in every exit path — missing it stalls the consumer.
+- **Do** set `onTermination` to release resources (network connections, observers, timers) when the consumer cancels.
+- **Do** choose a buffering policy — leaving it at `.unbounded` in a high-frequency stream can grow memory without bound.
+- **Do** annotate `onTermination` closures with `@Sendable` — the runtime can call them from any isolation domain.
+- **Don't** store a raw `AsyncStream.Continuation` in a non-actor type without synchronization — wrap it in an actor.
+- **Don't** `for await` without task-cancellation awareness — ensure the producer can stop cleanly when the task is cancelled.
+- **Don't** use `AsyncStream` when a simple `async` function returning a single value is sufficient.

--- a/skills/swift-concurrency/references/async-sequences.md
+++ b/skills/swift-concurrency/references/async-sequences.md
@@ -127,7 +127,7 @@ AsyncThrowingStream { continuation in
 Use `defer` to guarantee finish:
 
 ```swift
-AsyncThrowingStream { continuation in
+AsyncStream { continuation in
     Task {
         defer { continuation.finish() }
 
@@ -161,7 +161,7 @@ continuation.onTermination = { @Sendable _ in
 }
 ```
 
-The `@Sendable` annotation on the closure is required because `onTermination` can be called from any concurrency domain.
+The `onTermination` setter already requires a `@Sendable` closure, so the compiler infers it. Annotating `@Sendable` explicitly is recommended for clarity — a reminder that this closure may be invoked from any concurrency domain.
 
 ## Converting `Combine` publishers to `AsyncSequence`
 

--- a/skills/swift-concurrency/references/sendability.md
+++ b/skills/swift-concurrency/references/sendability.md
@@ -1,0 +1,190 @@
+# Sendability
+
+## When to use this reference
+
+Use when a type needs to cross a concurrency domain boundary, fixing `Sendable`-related compiler errors, annotating `@Sendable` closures, or deciding how to make a type safe to share across tasks.
+
+## What `Sendable` means
+
+`Sendable` indicates a type is safe to share across isolation domains (actors, tasks, threads). The compiler verifies this at compile time in Swift 6 (`SWIFT_STRICT_CONCURRENCY = complete`).
+
+A type is `Sendable` when:
+- All its stored state is immutable, or
+- All its stored state is itself `Sendable` and mutations are protected (e.g., inside an actor).
+
+## Implicit `Sendable` — value types
+
+`struct` and `enum` with all-`Sendable` stored properties are implicitly `Sendable`. No annotation needed.
+
+```swift
+// Implicitly Sendable — all properties are value types
+struct OrderSummary {
+
+    let orderId: String
+    let total: Decimal
+    let items: [OrderItem]   // OrderItem must also be Sendable
+}
+
+enum PaymentStatus {
+
+    case pending
+    case completed(transactionId: String)
+    case failed(reason: String)
+}
+```
+
+## Explicit `Sendable` conformance
+
+Conform explicitly when the compiler cannot verify sendability automatically:
+
+```swift
+// All stored properties are Sendable — explicit conformance is redundant but documents intent
+struct AuthToken: Sendable {
+
+    let value: String
+    let expiresAt: Date
+}
+```
+
+For `final class` with immutable state only:
+
+```swift
+final class RemoteConfigKey<Value: Sendable>: Sendable {
+
+    let name: String
+    let defaultValue: Value
+
+    init(name: String, defaultValue: Value) {
+        self.name = name
+        self.defaultValue = defaultValue
+    }
+}
+```
+
+## Actors are always `Sendable`
+
+An `actor` implicitly conforms to `Sendable` — it protects its own state, so it is safe to pass across domains.
+
+```swift
+actor TokenStore: Sendable { /* implicit */ }
+
+// Safe to pass across task boundaries
+let store = TokenStore()
+Task {
+    await store.store(access: "...", refresh: "...")
+}
+```
+
+## `@Sendable` closures
+
+Mark a closure `@Sendable` when it will be called from a different concurrency domain (e.g., passed to `Task`, `TaskGroup.addTask`, or `DispatchQueue` replacements).
+
+```swift
+func schedule(work: @Sendable @escaping () async -> Void) {
+    Task { await work() }
+}
+```
+
+The compiler enforces that a `@Sendable` closure only captures `Sendable` values:
+
+```swift
+class NonSendableService { /* ... */ }
+
+let service = NonSendableService()
+
+// Error: capture of 'service' with non-Sendable type in @Sendable closure
+Task {
+    service.doWork()
+}
+```
+
+Fix by making the service an actor, a value type, or passing `Sendable` data instead of the object.
+
+## Crossing isolation boundaries
+
+When passing a value from one isolation domain to another, it must be `Sendable`:
+
+```swift
+@MainActor
+func handleResult(_ result: SearchResult) {
+    self.results = [result]
+}
+
+// In a non-isolated async function:
+func search(query: String) async {
+    let result = try await searchService.search(query: query)
+    // SearchResult must be Sendable to cross into @MainActor
+    await handleResult(result)
+}
+```
+
+If `SearchResult` is a `struct` with `Sendable` fields, this compiles. If it is a `class`, make it `final` and all-immutable, or convert it to a struct.
+
+## `@unchecked Sendable` — escape hatch
+
+Use `@unchecked Sendable` when a type is provably thread-safe but the compiler cannot verify it (e.g., a third-party class protected by its own internal lock).
+
+```swift
+// Safe: SDWebImageManager uses its own internal serial queue for all state access.
+extension SDWebImageManager: @unchecked Sendable {}
+```
+
+Rules:
+- Always add a comment explaining the thread-safety guarantee.
+- Never use it on your own types — redesign for proper isolation instead.
+- Prefer making your wrapper an actor over marking the wrapped type `@unchecked Sendable`.
+
+## `sending` parameters (Swift 6.0+)
+
+The `sending` annotation allows passing a non-`Sendable` value across an isolation boundary as a one-way transfer — the caller loses access after the call:
+
+```swift
+func process(order: sending Order) async {
+    // order is now owned by this async context
+    await persist(order)
+}
+```
+
+Use `sending` to avoid requiring `Sendable` on domain model types that are only ever passed one way (never shared).
+
+## Common patterns
+
+### Domain model as struct (preferred)
+
+```swift
+// Sendable implicitly — all fields are value types
+struct UserProfile {
+    let id: String
+    let name: String
+    let avatarURL: URL?
+}
+```
+
+### DTO bridging at the isolation boundary
+
+Keep non-Sendable third-party model types inside their isolation domain; bridge to a `Sendable` struct at the boundary:
+
+```swift
+actor RealmDataSource {
+
+    func fetchUser(id: String) async -> UserProfile {
+        let realmUser = realm.object(ofType: RealmUser.self, forPrimaryKey: id)
+        // Convert inside the actor before crossing the boundary
+        return UserProfile(
+            id: realmUser?.id ?? "",
+            name: realmUser?.name ?? "",
+            avatarURL: realmUser?.avatarURL.flatMap(URL.init)
+        )
+    }
+}
+```
+
+## Do / Don't
+
+- **Do** prefer `struct` and `enum` — they are `Sendable` for free when their properties are.
+- **Do** make `class` types that cross boundaries `final` with only immutable stored properties.
+- **Do** make `Sendable` class with all properties `Sendable`.
+- **Do** convert to a `Sendable` struct at actor boundaries rather than marking reference types `@unchecked Sendable`.
+- **Do** add a thread-safety comment whenever using `@unchecked Sendable`.
+- **Don't** apply `@unchecked Sendable` to mutable reference types without lock-based protection.
+- **Don't** ignore `Sendable` warnings in Swift 5 mode — they become errors in Swift 6.

--- a/skills/swift-concurrency/references/structured-concurrency.md
+++ b/skills/swift-concurrency/references/structured-concurrency.md
@@ -1,0 +1,238 @@
+# Structured Concurrency
+
+## When to use this reference
+
+Use when spawning concurrent work, running parallel async calls, managing task lifetimes, handling task cancellation, or choosing between structured (`async let`, `TaskGroup`) and unstructured (`Task`) concurrency.
+
+## The structured concurrency hierarchy
+
+In structured concurrency, child tasks:
+- Are always tied to their parent's lifetime.
+- Inherit the parent's priority and task-local values.
+- Automatically cancel if the parent is cancelled or throws.
+- Are always awaited before the parent returns.
+
+Prefer structured forms (`async let`, `TaskGroup`) over `Task { }` (unstructured).
+
+## `async let` — parallel independent calls
+
+Use when you have a fixed number of independent async operations and want them to run concurrently.
+
+```swift
+func loadProductPage(id: String) async throws -> ProductPage {
+    async let product = productRepository.fetch(id: id)
+    async let reviews = reviewRepository.fetchReviews(productId: id)
+    async let recommendations = recommendationRepository.fetch(productId: id)
+
+    // All three run concurrently; awaited here
+    return try await ProductPage(
+        product: product,
+        reviews: reviews,
+        recommendations: recommendations
+    )
+}
+```
+
+Rules:
+- `async let` bindings start immediately when declared.
+- If one throws, the others are cancelled automatically.
+- Must be `await`ed before the function returns (the compiler enforces this).
+
+## `TaskGroup` — dynamic fan-out
+
+Use when the number of concurrent operations is determined at runtime.
+
+### Basic fan-out and collect
+
+```swift
+func prefetchImages(urls: [URL]) async -> [URL: UIImage] {
+    await withTaskGroup(of: (URL, UIImage)?.self) { group in
+        for url in urls {
+            group.addTask {
+                guard let image = try? await downloadImage(from: url) else { return nil }
+                return (url, image)
+            }
+        }
+
+        var result: [URL: UIImage] = [:]
+        for await pair in group {
+            if let (url, image) = pair {
+                result[url] = image
+            }
+        }
+        return result
+    }
+}
+```
+
+### Throwing fan-out
+
+```swift
+func fetchAll(ids: [String]) async throws -> [Detail] {
+    try await withThrowingTaskGroup(of: Detail.self) { group in
+        for id in ids {
+            group.addTask { try await repository.fetchDetail(id: id) }
+        }
+        return try await group.reduce(into: []) { $0.append($1) }
+    }
+}
+```
+
+If any child task throws, the group cancels all remaining children and rethrows.
+
+### `DiscardingTaskGroup` — fire-and-forget with backpressure
+
+Use when results are not collected but you want bounded concurrency:
+
+```swift
+await withDiscardingTaskGroup { group in
+    for event in eventStream {
+        group.addTask { await process(event) }
+    }
+}
+```
+
+`DiscardingTaskGroup` discards child results as soon as they finish — lower memory overhead for large fan-outs.
+
+## Unstructured tasks — `Task { }`
+
+Use `Task { }` only when you genuinely cannot attach work to a parent async context (e.g., inside a `UIViewController` lifecycle method or a SwiftUI `.task` replacement).
+
+```swift
+// In a UIViewController — no async context available
+override func viewDidLoad() {
+    super.viewDidLoad()
+    Task {
+        await viewModel.load()
+    }
+}
+```
+
+Store the `Task` handle when you need to cancel it:
+
+```swift
+private var loadTask: Task<Void, Never>?
+
+override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+    loadTask?.cancel()
+}
+
+func beginLoad() {
+    loadTask = Task { await viewModel.load() }
+}
+```
+
+### `Task.detached` — avoid unless necessary
+
+`Task.detached` does **not** inherit the parent's actor, priority, or task-locals. It truly detaches from the current context. Only use it when you explicitly want a lower-priority background task with no inherited context:
+
+```swift
+// Rare legitimate use: background index build that must not inherit @MainActor context
+Task.detached(priority: .background) {
+    await searchIndex.rebuild()
+}
+```
+
+## Task cancellation
+
+Swift concurrency uses cooperative cancellation — tasks must check for cancellation themselves.
+
+### Checking cancellation
+
+```swift
+func processItems(_ items: [Item]) async throws {
+    for item in items {
+        try Task.checkCancellation()   // Throws CancellationError if cancelled
+        await process(item)
+    }
+}
+```
+
+Or check without throwing:
+
+```swift
+guard !Task.isCancelled else { return }
+```
+
+### Propagating cancellation to child work
+
+`async let` and `TaskGroup` child tasks are cancelled automatically when the parent is cancelled. For `URLSession`, cancellation is also propagated automatically.
+
+For manual cleanup on cancellation:
+
+```swift
+func fetchWithCleanup() async throws -> Data {
+    let task = Task {
+        try await networkSession.data(from: url).0
+    }
+
+    do {
+        return try await task.value
+    } catch is CancellationError {
+        await cleanup()
+        throw CancellationError()
+    }
+}
+```
+
+### `withTaskCancellationHandler`
+
+React synchronously to cancellation (e.g., to cancel a legacy callback API):
+
+```swift
+func fetchLegacy(url: URL) async throws -> Data {
+    try await withTaskCancellationHandler {
+        try await withCheckedThrowingContinuation { continuation in
+            let request = legacySession.dataTask(with: url) { data, _, error in
+                if let data { continuation.resume(returning: data) }
+                else { continuation.resume(throwing: error ?? URLError(.unknown)) }
+            }
+            request.resume()
+        }
+    } onCancel: {
+        // Called synchronously on cancellation
+        request.cancel()   // Cancel the legacy task
+    }
+}
+```
+
+## Task priority
+
+```swift
+Task(priority: .userInitiated) { /* user-visible work */ }
+Task(priority: .utility)       { /* background enrichment */ }
+Task(priority: .background)    { /* prefetch / index */ }
+```
+
+Child tasks inherit the parent's priority unless overridden. `TaskGroup.addTask(priority:)` can lower priority for specific children.
+
+## Task-local values
+
+Propagate ambient context (e.g., request ID, logging context) without threading it through every function signature:
+
+```swift
+enum RequestContext {
+    @TaskLocal static var requestId: String = "unknown"
+}
+
+func handleRequest(id: String) async {
+    await RequestContext.$requestId.withValue(id) {
+        await processSteps()   // All child tasks see id
+    }
+}
+
+func processSteps() async {
+    print(RequestContext.requestId)   // Reads inherited value
+}
+```
+
+## Do / Don't
+
+- **Do** use `async let` for a fixed set of parallel calls — it is the clearest and safest form.
+- **Do** use `TaskGroup` when the count of parallel work items is dynamic.
+- **Do** call `try Task.checkCancellation()` at the top of each loop iteration in long-running tasks.
+- **Do** store `Task` handles from `Task { }` when you need to cancel them later (e.g., on view disappear).
+- **Don't** use `Task.detached` unless you have an explicit reason to shed the parent context.
+- **Don't** use `Task { }` inside an actor or `async` function when `async let` or `TaskGroup` would work.
+- **Don't** swallow `CancellationError` — let it propagate unless you have explicit cleanup to perform.

--- a/skills/swift-concurrency/references/structured-concurrency.md
+++ b/skills/swift-concurrency/references/structured-concurrency.md
@@ -182,17 +182,18 @@ React synchronously to cancellation (e.g., to cancel a legacy callback API):
 
 ```swift
 func fetchLegacy(url: URL) async throws -> Data {
+    var request: URLSessionDataTask?
     try await withTaskCancellationHandler {
         try await withCheckedThrowingContinuation { continuation in
-            let request = legacySession.dataTask(with: url) { data, _, error in
+            request = legacySession.dataTask(with: url) { data, _, error in
                 if let data { continuation.resume(returning: data) }
                 else { continuation.resume(throwing: error ?? URLError(.unknown)) }
             }
-            request.resume()
+            request?.resume()
         }
     } onCancel: {
         // Called synchronously on cancellation
-        request.cancel()   // Cancel the legacy task
+        request?.cancel()   // Cancel the legacy task
     }
 }
 ```

--- a/skills/swift-concurrency/references/structured-concurrency.md
+++ b/skills/swift-concurrency/references/structured-concurrency.md
@@ -86,7 +86,7 @@ Use when results are not collected but you want bounded concurrency:
 
 ```swift
 await withDiscardingTaskGroup { group in
-    for event in eventStream {
+    for await event in eventStream {
         group.addTask { await process(event) }
     }
 }
@@ -157,23 +157,67 @@ guard !Task.isCancelled else { return }
 
 ### Propagating cancellation to child work
 
-`async let` and `TaskGroup` child tasks are cancelled automatically when the parent is cancelled. For `URLSession`, cancellation is also propagated automatically.
+#### Structured (preferred)
 
-For manual cleanup on cancellation:
+Bound to parent, inherit context, automatic cancellation:
 
 ```swift
-func fetchWithCleanup() async throws -> Data {
-    let task = Task {
-        try await networkSession.data(from: url).0
-    }
+// async let
+async let data1 = fetch(1)
+async let data2 = fetch(2)
+let results = await [data1, data2]
 
-    do {
-        return try await task.value
-    } catch is CancellationError {
-        await cleanup()
-        throw CancellationError()
+// Task groups
+await withTaskGroup(of: Data.self) { group in
+    group.addTask { await fetch(1) }
+    group.addTask { await fetch(2) }
+}
+
+// Holding reference then cancel
+let downloadTask = Task {
+    try await withThrowingTaskGroup(of: Data.self) { group in
+        for url in urls {  // Assume urls is an array
+            group.addTask {
+                try Task.checkCancellation()
+                let (data, _) = try await URLSession.shared.data(from: url)
+                return data
+            }
+        }
+        var results: [Data] = []
+        for try await data in group {
+            results.append(data)
+        }
+        return results
     }
 }
+
+// Cancel after some time
+downloadTask.cancel()  // Children inherit and stop at checks
+
+```
+
+#### Unstructured
+
+Independent lifecycle, manual cancellation; unstructured concurrency, cancellation doesn’t propagate automatically. Use manual checks or link tasks.
+
+```swift
+let task = Task {
+    await doWork() // Await for the result
+}
+
+// Manually propagate
+let parent = Task {
+    let child = Task {
+        try Task.checkCancellation()  // Will throw if parent cancelled
+        // Work...
+    }
+    // Manually propagate if needed
+    if Task.isCancelled {
+        child.cancel()
+    }
+    try await child.value
+}
+parent.cancel()  // Child gets cancelled manually
 ```
 
 ### `withTaskCancellationHandler`


### PR DESCRIPTION
- #690

## What happened 👀

Defined a base skills set for swift concurrency, which covered the following areas
 - SKILL.md: behavior contract, canonical patterns, verification checklist
   - references/actors.md: actor isolation, nonisolated, global actors, Mutex vs Actor
   - references/sendability.md: `Sendable`, `@unchecked Sendable`, sending parameters
   - references/structured-concurrency.md: async let, TaskGroup, Task cancellation
   - references/async-sequences.md: AsyncStream, AsyncThrowingStream, buffering

## Insight 📝

This adds a Swift 6 Concurrency AI agent skill to help Claude Code assist developers writing correct concurrent Swift code, only forward-looking patterns aligned with Swift 6's strict data-race-safety model.

- Diagnose and fix data race compiler errors correctly — never suppressing them with nonisolated(unsafe) without justification
- Choose the right primitive — actor for async shared state, @MainActor for UI, Mutex only for short synchronous critical sections
- Apply structured concurrency (async let, TaskGroup) instead of ad-hoc Task { } chains
- Handle AsyncStream continuations safely, ensuring .finish() is always called
Propagate task cancellation correctly through long-running operations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Swift 6 strict-concurrency skill/workflow and companion reference guides covering actors and @MainActor guidance, structured concurrency patterns, async sequences, and Sendable rules.
  * Includes triage/routing guidance, canonical patterns and examples, do/don’t checklists, and verification steps for cancellation, stream/continuation termination, and safe shared-state practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->