### PR TITLE
[#556] Improve Workflow by Adding Initial Danger Job

### DIFF
--- a/.cicdtemplate/.github/self-hosted-workflows/automatic_pull_request_review.yml
+++ b/.cicdtemplate/.github/self-hosted-workflows/automatic_pull_request_review.yml
@@ -9,8 +9,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  review_pull_request:
-    name: Pull request review by Danger
+  early_review:
+    name: Early PR review by Danger
     runs-on: [self-hosted, macOS]
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
@@ -25,8 +25,39 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gems-
 
-    - name: Install tools with mise
-      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # jdx/mise-action@v4.0.1
+    - name: Setup CI environment
+      uses: ./.github/actions/setup-ci-environment
+      with:
+        bundler-cache: "false"
+        bundle-install-command: "bundle config set --local path 'vendor/bundle' && bundle install"
+
+    - name: Early PR review by Danger
+      env:
+        DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: bundle exec danger --dangerfile=template/EarlyDangerfile
+
+  build_and_test:
+    name: Build and Test
+    runs-on: [self-hosted, macOS]
+    needs: early_review
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
+      with:
+        fetch-depth: 0
+
+    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # actions/cache@v5.0.4
+      id: bundlerCache
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+
+    - name: Setup CI environment
+      uses: ./.github/actions/setup-ci-environment
+      with:
+        bundler-cache: "false"
+        bundle-install-command: "bundle config set --local path 'vendor/bundle' && bundle install"
 
     - name: Setup ENV file
       env:
@@ -36,8 +67,8 @@ jobs:
         echo $ENV | base64 --decode > .env
 
     - name: Bundle install
-      run: bundle install --path vendor/bundle
-      
+      run: bundle config set --local path 'vendor/bundle' && bundle install
+
     - name: Run Arkana
       run: bundle exec arkana
 
@@ -55,7 +86,7 @@ jobs:
     - name: Clean up previous code coverage report
       run: bundle exec fastlane cleanUpOutput
 
-    - name: Review pull request by Danger
+    - name: Post-build PR review by Danger
       env:
         DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: bundle exec danger

--- a/.cicdtemplate/.github/self-hosted-workflows/automatic_pull_request_review.yml
+++ b/.cicdtemplate/.github/self-hosted-workflows/automatic_pull_request_review.yml
@@ -9,8 +9,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  early_review:
-    name: Early PR review by Danger
+  prebuild_review:
+    name: Prebuild PR review by Danger
     runs-on: [self-hosted, macOS]
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
@@ -31,15 +31,15 @@ jobs:
         bundler-cache: "false"
         bundle-install-command: "bundle config set --local path 'vendor/bundle' && bundle install"
 
-    - name: Early PR review by Danger
+    - name: Prebuild PR review by Danger
       env:
         DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: bundle exec danger --dangerfile=template/EarlyDangerfile
+      run: bundle exec danger --dangerfile=template/PrebuildDangerfile
 
   build_and_test:
     name: Build and Test
     runs-on: [self-hosted, macOS]
-    needs: early_review
+    needs: prebuild_review
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:

--- a/.cicdtemplate/.github/workflows/automatic_pull_request_review.yml
+++ b/.cicdtemplate/.github/workflows/automatic_pull_request_review.yml
@@ -9,8 +9,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  review_pull_request:
-    name: Pull request review by Danger
+  early_review:
+    name: Early PR review by Danger
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
@@ -29,7 +29,35 @@ jobs:
       uses: ./.github/actions/setup-ci-environment
       with:
         bundler-cache: "false"
-        bundle-install-command: "bundle install --path vendor/bundle"
+        bundle-install-command: "bundle config set --local path 'vendor/bundle' && bundle install"
+
+    - name: Early PR review by Danger
+      env:
+        DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: bundle exec danger --dangerfile=template/EarlyDangerfile
+
+  build_and_test:
+    name: Build and Test
+    runs-on: macOS-latest
+    needs: early_review
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
+      with:
+        fetch-depth: 0
+
+    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # actions/cache@v5.0.4
+      id: bundlerCache
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+
+    - name: Setup CI environment
+      uses: ./.github/actions/setup-ci-environment
+      with:
+        bundler-cache: "false"
+        bundle-install-command: "bundle config set --local path 'vendor/bundle' && bundle install"
 
     - name: Setup ENV file
       env:
@@ -55,7 +83,7 @@ jobs:
     - name: Clean up previous code coverage report
       run: bundle exec fastlane cleanUpOutput
 
-    - name: Review pull request by Danger
+    - name: Post-build PR review by Danger
       env:
         DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: bundle exec danger

--- a/.cicdtemplate/.github/workflows/automatic_pull_request_review.yml
+++ b/.cicdtemplate/.github/workflows/automatic_pull_request_review.yml
@@ -9,8 +9,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  early_review:
-    name: Early PR review by Danger
+  prebuild_review:
+    name: Prebuild PR review by Danger
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
@@ -31,15 +31,15 @@ jobs:
         bundler-cache: "false"
         bundle-install-command: "bundle config set --local path 'vendor/bundle' && bundle install"
 
-    - name: Early PR review by Danger
+    - name: Prebuild PR review by Danger
       env:
         DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: bundle exec danger --dangerfile=template/EarlyDangerfile
+      run: bundle exec danger --dangerfile=template/PrebuildDangerfile
 
   build_and_test:
     name: Build and Test
     runs-on: macOS-latest
-    needs: early_review
+    needs: prebuild_review
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
       with:

--- a/template/Dangerfile
+++ b/template/Dangerfile
@@ -1,25 +1,7 @@
 # frozen_string_literal: true
 
-# Warn when there is a big PR
-warn("This pull request is quite big (#{git.lines_of_code} lines changed), please consider splitting it into multiple pull requests.") if git.lines_of_code > 500
-
-# Warn to encourage that labels should have been used on the PR
-warn("This pull request doesn't have any labels, please consider to add labels to this pull request.") if github.pr_labels.empty?
-
-# SwiftFormat
-swiftformat.binary_path = 'swiftformat'
-swiftformat.exclude = %w(**/*generated.swift)
-swiftformat.check_format
-
-# Swiftlint
-swiftlint.binary_path = 'swiftlint'
-swiftlint.config_file = '.swiftlint.yml'
-swiftlint.max_num_violations = 20
-swiftlint.lint_files(
-  inline_mode: true,
-  fail_on_error: true,
-  additional_swiftlint_args: '--strict'
-)
+# Post-build checks that require build artifacts
+# This runs after build/test to analyze build results
 
 xcodeproj = "./{PROJECT_NAME}.xcodeproj"
 xcresultPath = "./fastlane/test_output/{PROJECT_NAME} Staging.xcresult"

--- a/template/EarlyDangerfile
+++ b/template/EarlyDangerfile
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Early checks that don't require build artifacts
+# This runs before build/test to provide faster feedback
+
+# Warn when there is a big PR
+warn("This pull request is quite big (#{git.lines_of_code} lines changed), please consider splitting it into multiple pull requests.") if git.lines_of_code > 500
+
+# Warn to encourage that labels should have been used on the PR
+warn("This pull request doesn't have any labels, please consider to add labels to this pull request.") if github.pr_labels.empty?
+
+# SwiftFormat
+swiftformat.binary_path = 'swiftformat'
+swiftformat.exclude = %w(**/*generated.swift)
+swiftformat.check_format
+
+# Swiftlint
+swiftlint.binary_path = 'swiftlint'
+swiftlint.config_file = '.swiftlint.yml'
+swiftlint.max_num_violations = 20
+swiftlint.lint_files(
+  inline_mode: true,
+  fail_on_error: true,
+  additional_swiftlint_args: '--strict'
+)

--- a/template/PrebuildDangerfile
+++ b/template/PrebuildDangerfile
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Early checks that don't require build artifacts
-# This runs before build/test to provide faster feedback
+# Prebuild review: no build artifacts; runs before build/test for faster feedback
 
 # Warn when there is a big PR
 warn("This pull request is quite big (#{git.lines_of_code} lines changed), please consider splitting it into multiple pull requests.") if git.lines_of_code > 500


### PR DESCRIPTION
- Close #556 

## What happened 👀

- Move early check danger jobs: check big PRs, missing label, swiftformat, and swiftlint to a new file `EarlyDangerfile`.
- Run `early_review` job at the initial of `automatic_pull_request_review` workflow.
- Correct bundle install command.

## Insight 📝

N/A
## Proof Of Work 📹

<img width="1679" height="324" alt="image" src="https://github.com/user-attachments/assets/9c491dff-33f9-461e-9bc6-a0b5ea62fee5" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restructured pull request validation into two stages: pre-build checks for code style, PR size, and labels, followed by post-build verification for build results and coverage
  * Enhanced code quality by running SwiftFormat and SwiftLint validation earlier in the CI/CD pipeline
  * Optimized bundler configuration for improved caching efficiency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->