### PR TITLE
[#652] Persist PR report TS via artifact instead of cache

### DIFF
--- a/.github/workflows/pr_report.yml
+++ b/.github/workflows/pr_report.yml
@@ -32,9 +32,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          run_id=$(gh api \
+          run_id=""
+          for candidate in $(gh api \
             "repos/${{ github.repository }}/actions/workflows/pr_report.yml/runs?status=success&per_page=20" \
-            --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }})] | .[0].id // empty")
+            --jq '.workflow_runs[] | select(.id != ${{ github.run_id }}) | .id'); do
+            has_artifact=$(gh api \
+              "repos/${{ github.repository }}/actions/runs/${candidate}/artifacts" \
+              --jq 'any(.artifacts[]?; .name == "pr-report-ts")')
+            if [ "$has_artifact" = "true" ]; then
+              run_id="$candidate"
+              break
+            fi
+          done
           echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
 
       - name: Download daily TS artifact

--- a/.github/workflows/pr_report.yml
+++ b/.github/workflows/pr_report.yml
@@ -15,7 +15,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
-  actions: write
+  actions: read
 
 jobs:
   report:
@@ -27,17 +27,24 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Get today's date
-        id: date
-        run: echo "date=$(date -u +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+      - name: Find previous successful run
+        id: prev_run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          run_id=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/pr_report.yml/runs?status=success&per_page=20" \
+            --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }})] | .[0].id // empty")
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
 
-      - name: Restore daily TS cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache/restore@v5.0.5
+      - name: Download daily TS artifact
+        if: steps.prev_run.outputs.run_id != ''
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # actions/download-artifact@v4.3.0
         with:
-          path: .pr_report_ts
-          key: pr-report-ts-${{ steps.date.outputs.date }}-${{ github.run_id }}
-          restore-keys: |
-            pr-report-ts-${{ steps.date.outputs.date }}-
+          name: pr-report-ts
+          run-id: ${{ steps.prev_run.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run PR Report
         env:
@@ -54,9 +61,13 @@ jobs:
           fi
           python3 scripts/pr_report.py
 
-      - name: Save daily TS cache
+      - name: Upload daily TS artifact
         if: always()
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache/save@v5.0.5
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # actions/upload-artifact@v4.6.2
         with:
+          name: pr-report-ts
           path: .pr_report_ts
-          key: pr-report-ts-${{ steps.date.outputs.date }}-${{ github.run_id }}
+          retention-days: 1
+          overwrite: true
+          include-hidden-files: true
+          if-no-files-found: ignore

--- a/scripts/pr_report.py
+++ b/scripts/pr_report.py
@@ -3,7 +3,7 @@
 PR Report - Categorize open PRs by action required and post to Slack.
 
 Posts a new message at the start of each day and updates it on subsequent runs.
-The daily Slack message timestamp is stored in PR_REPORT_TS_FILE (managed via Actions cache).
+The daily Slack message timestamp is stored in PR_REPORT_TS_FILE (managed via Actions artifact).
 
 Environment variables:
     GITHUB_USER           Login of the user to evaluate PRs from (e.g. github.actor)


### PR DESCRIPTION
- Close #652

## What happened 👀

Replace the GitHub Actions cache used to persist the daily Slack message timestamp with a workflow artifact. Each run looks up the previous successful run via the REST API and downloads its `pr-report-ts` artifact, then uploads its own `pr-report-ts` at the end.

## Insight 📝

GitHub Actions caches are isolated per branch by design — non-default branches cannot read or write the default branch's cache scope. With the previous workflow, every branch push wrote a per-branch cache, no cross-branch reads matched, and each push posted a new Slack message instead of updating the existing one. The platform documentation on `actions/cache` explicitly states: _"Reusing cache across feature branches is not allowed today to provide cache isolation."_

Artifacts, unlike caches, are scoped to a workflow **run** rather than a branch. `actions/download-artifact@v4` accepts a `run-id` so a later run on any branch can pull a previous run's artifact using just `GITHUB_TOKEN` with `actions: read`. This makes it the natural fit for storing the daily TS:

- A small `gh api` step queries `actions/workflows/pr_report.yml/runs?status=success` and picks the most recent successful run other than the current one.
- `actions/download-artifact` pulls that run's `pr-report-ts` artifact (`continue-on-error` covers the very first run, when no prior artifact exists).
- The Python script's existing `.pr_report_ts` read/write logic and date-stamp check is unchanged — if the file's date doesn't match today, it posts a fresh message; otherwise it calls `chat.update`.
- `actions/upload-artifact` uploads the new `.pr_report_ts` at the end with `retention-days: 1` to keep storage tidy.

`permissions.actions` is downgraded from `write` (cache save) to `read` (artifact lookup + download).

No changes to `scripts/pr_report.py`.

## Proof Of Work 📹

https://github.com/nimblehq/ios-templates/actions/runs/25307151906

<img width="605" height="293" alt="CleanShot 2026-05-04 at 14 44 25" src="https://github.com/user-attachments/assets/72b0fc2a-3e2f-4369-95f4-993828f29c69" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized pull request workflow efficiency by refining artifact reuse and adjusting token permissions for enhanced security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->