### PR TITLE
[#710] Apply native NavigationStack routing foundation

### DIFF
--- a/scripts/iOSTemplateMaker/Sources/iOSTemplateMaker/SetUpiOSProject.swift
+++ b/scripts/iOSTemplateMaker/Sources/iOSTemplateMaker/SetUpiOSProject.swift
@@ -8,6 +8,7 @@ class SetUpIOSProject {
     private let CONSTANT_BUNDLE_STAGING = "{BUNDLE_ID_STAGING}"
     private let CONSTANT_BUNDLE_DEV = "{BUNDLE_ID_DEV}"
     private let CONSTANT_MINIMUM_VERSION = "{TARGET_VERSION}"
+    private let CONSTANT_APP_STORE_ID = "{APP_STORE_ID}"
     private let fileManager = FileManager.default
 
     private var bundleIdProduction = ""
@@ -15,6 +16,7 @@ class SetUpIOSProject {
     private var bundleIdDev = ""
     private var projectName = ""
     private var minimumVersion = ""
+    private var appStoreId = ""
     private var cicd = ""
     private var githubRunner = ""
     private var setupConstants = false
@@ -27,6 +29,7 @@ class SetUpIOSProject {
         bundleIdDev: String = "",
         projectName: String = "",
         minimumVersion: String = "",
+        appStoreId: String = "",
         cicd: String = "",
         githubRunner: String = "",
         setupConstants: Bool = false
@@ -36,6 +39,7 @@ class SetUpIOSProject {
         self.bundleIdDev = bundleIdDev
         self.projectName = projectName
         self.minimumVersion = minimumVersion
+        self.appStoreId = appStoreId
         self.cicd = cicd
         self.githubRunner = githubRunner
         self.setupConstants = setupConstants
@@ -167,6 +171,20 @@ class SetUpIOSProject {
                 onValidate: validateVersion
             )
         }
+
+        if appStoreId.isEmpty {
+            if isCI {
+                appStoreId = "000000000"
+            } else {
+                tryMoveDown()
+                appStoreId = ask(
+                    "Which is the App Store app ID?",
+                    note: "Default: 000000000. Use the numeric ID from App Store Connect.",
+                    defaultValue: "000000000",
+                    onValidate: validateAppStoreId
+                )
+            }
+        }
     }
 
     private func replaceFileStructure() throws {
@@ -196,6 +214,7 @@ class SetUpIOSProject {
         fileManager.replaceAllOccurrences(of: CONSTANT_BUNDLE_PRODUCTION, to: bundleIdProduction)
         fileManager.replaceAllOccurrences(of: CONSTANT_PROJECT_NAME, to: projectNameNoSpace)
         fileManager.replaceAllOccurrences(of: CONSTANT_MINIMUM_VERSION, to: minimumVersion)
+        fileManager.replaceAllOccurrences(of: CONSTANT_APP_STORE_ID, to: appStoreId)
     }
 
     private func runTuist() throws {
@@ -283,6 +302,17 @@ class SetUpIOSProject {
         let valid = version ~= versionRegex
 
         return valid ? nil : "Please pick a valid version with pattern {x.y}"
+    }
+
+    private func validateAppStoreId(_ appStoreId: String) -> String? {
+        if appStoreId.isEmpty {
+            return nil
+        }
+
+        let appStoreIdRegex = "^[0-9]+$"
+        let valid = appStoreId ~= appStoreIdRegex
+
+        return valid ? nil : "Please input a valid numeric App Store app ID"
     }
 
     private func inferDevBundleId() -> String {

--- a/scripts/iOSTemplateMaker/Sources/iOSTemplateMaker/iOSTemplateMaker.swift
+++ b/scripts/iOSTemplateMaker/Sources/iOSTemplateMaker/iOSTemplateMaker.swift
@@ -29,6 +29,8 @@ extension iOSTemplateMaker {
         var projectName: String?
         @Option(help: "The minimum iOS version (14.0)")
         var minimumVersion: String?
+        @Option(help: "The App Store app ID used to build the App Store URL")
+        var appStoreId: String?
         @Option(help: "The CI/CD service (github, bitrise, codemagic, none)")
         var cicd: String?
         @Option(help: "The GitHub runner type (macos-latest, self-hosted) — only used when --cicd=github")
@@ -43,6 +45,7 @@ extension iOSTemplateMaker {
                 bundleIdDev: bundleIdDev.string,
                 projectName: projectName.string,
                 minimumVersion: minimumVersion.string,
+                appStoreId: appStoreId.string,
                 cicd: cicd.string,
                 githubRunner: githubRunner.string,
                 setupConstants: setupConstants

--- a/template/Modules/Domain/Sources/UseCases/CheckForceUpdateUseCase.swift
+++ b/template/Modules/Domain/Sources/UseCases/CheckForceUpdateUseCase.swift
@@ -30,7 +30,7 @@ public struct CheckForceUpdateUseCase: CheckForceUpdateUseCaseProtocol, Sendable
     }
 }
 
-private extension CheckForceUpdateUseCase {
+public extension CheckForceUpdateUseCase {
 
     static func defaultCurrentVersion() -> AppVersion {
         let string = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""

--- a/template/Tuist/Interfaces/SwiftUI/Sources/Application/App.swift
+++ b/template/Tuist/Interfaces/SwiftUI/Sources/Application/App.swift
@@ -4,6 +4,8 @@ import SwiftUI
 @main
 struct {PROJECT_NAME}App: App {
 
+    @StateObject private var router = AppRouter()
+
     init() {
         #if DEBUG
         Analytics.shared.configure(
@@ -18,6 +20,7 @@ struct {PROJECT_NAME}App: App {
     var body: some Scene {
         WindowGroup {
             LandingView()
+                .environmentObject(router)
         }
     }
 }

--- a/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Coordinators/AppRoute.swift
+++ b/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Coordinators/AppRoute.swift
@@ -1,4 +1,11 @@
-enum AppRoute: Hashable {
+enum AppRoute: Hashable, Identifiable {
 
     case settings
+
+    var id: String {
+        switch self {
+        case .settings:
+            return "settings"
+        }
+    }
 }

--- a/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Coordinators/AppRoute.swift
+++ b/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Coordinators/AppRoute.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum AppRoute: Hashable {
+
+    case settings
+}

--- a/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Coordinators/AppRoute.swift
+++ b/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Coordinators/AppRoute.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 enum AppRoute: Hashable {
 
     case settings

--- a/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Coordinators/AppRouter.swift
+++ b/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Coordinators/AppRouter.swift
@@ -4,9 +4,14 @@ import SwiftUI
 final class AppRouter: ObservableObject {
 
     @Published var path: [AppRoute] = []
+    @Published var fullScreenRoute: AppRoute?
 
     func push(_ route: AppRoute) {
         path.append(route)
+    }
+
+    func presentFullScreen(_ route: AppRoute) {
+        fullScreenRoute = route
     }
 
     func pop() {
@@ -17,5 +22,9 @@ final class AppRouter: ObservableObject {
 
     func popToRoot() {
         path.removeAll()
+    }
+
+    func dismissFullScreen() {
+        fullScreenRoute = nil
     }
 }

--- a/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Coordinators/AppRouter.swift
+++ b/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Coordinators/AppRouter.swift
@@ -10,6 +10,7 @@ final class AppRouter: ObservableObject {
     }
 
     @Published var routes: [AppRoute] = []
+    @Published var fullScreenRoutes: [AppRoute] = []
     @Published var coverRoute: AppRoute?
     @Published var fullScreenRoute: AppRoute?
 
@@ -20,8 +21,12 @@ final class AppRouter: ObservableObject {
     func present(_ route: AppRoute, style: PresentationStyle = .fullScreenCover) {
         switch style {
         case .cover:
+            fullScreenRoute = nil
+            fullScreenRoutes.removeAll()
             coverRoute = route
         case .fullScreenCover:
+            coverRoute = nil
+            fullScreenRoutes.removeAll()
             fullScreenRoute = route
         }
     }
@@ -44,11 +49,33 @@ final class AppRouter: ObservableObject {
         routes.removeAll()
     }
 
+    func pushInFullScreen(_ route: AppRoute) {
+        fullScreenRoutes.append(route)
+    }
+
+    func popFullScreen() {
+        guard !fullScreenRoutes.isEmpty else { return }
+
+        fullScreenRoutes.removeLast()
+    }
+
+    func popFullScreenToRoot() {
+        fullScreenRoutes.removeAll()
+    }
+
     func dismissCover() {
         coverRoute = nil
     }
 
     func dismissFullScreen() {
         fullScreenRoute = nil
+        fullScreenRoutes.removeAll()
+    }
+
+    func reset() {
+        routes.removeAll()
+        coverRoute = nil
+        fullScreenRoute = nil
+        fullScreenRoutes.removeAll()
     }
 }

--- a/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Coordinators/AppRouter.swift
+++ b/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Coordinators/AppRouter.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+@MainActor
+final class AppRouter: ObservableObject {
+
+    @Published var path: [AppRoute] = []
+
+    func push(_ route: AppRoute) {
+        path.append(route)
+    }
+
+    func pop() {
+        guard !path.isEmpty else { return }
+
+        path.removeLast()
+    }
+
+    func popToRoot() {
+        path.removeAll()
+    }
+}

--- a/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Coordinators/AppRouter.swift
+++ b/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Coordinators/AppRouter.swift
@@ -3,25 +3,49 @@ import SwiftUI
 @MainActor
 final class AppRouter: ObservableObject {
 
-    @Published var path: [AppRoute] = []
+    enum PresentationStyle {
+
+        case cover
+        case fullScreenCover
+    }
+
+    @Published var routes: [AppRoute] = []
+    @Published var coverRoute: AppRoute?
     @Published var fullScreenRoute: AppRoute?
 
     func push(_ route: AppRoute) {
-        path.append(route)
+        routes.append(route)
+    }
+
+    func present(_ route: AppRoute, style: PresentationStyle = .fullScreenCover) {
+        switch style {
+        case .cover:
+            coverRoute = route
+        case .fullScreenCover:
+            fullScreenRoute = route
+        }
     }
 
     func presentFullScreen(_ route: AppRoute) {
-        fullScreenRoute = route
+        present(route, style: .fullScreenCover)
+    }
+
+    func presentCover(_ route: AppRoute) {
+        present(route, style: .cover)
     }
 
     func pop() {
-        guard !path.isEmpty else { return }
+        guard !routes.isEmpty else { return }
 
-        path.removeLast()
+        routes.removeLast()
     }
 
     func popToRoot() {
-        path.removeAll()
+        routes.removeAll()
+    }
+
+    func dismissCover() {
+        coverRoute = nil
     }
 
     func dismissFullScreen() {

--- a/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Modules/Home/HomeView.swift
+++ b/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Modules/Home/HomeView.swift
@@ -4,6 +4,7 @@ struct HomeView: View {
 
     var onSignOut: () -> Void = {}
     var onShowSettings: () -> Void = {}
+    var onPresentSettings: () -> Void = {}
 
     var body: some View {
         VStack(spacing: 20) {
@@ -17,6 +18,9 @@ struct HomeView: View {
                 .foregroundStyle(.secondary)
 
             Button("Open Settings", action: onShowSettings)
+                .buttonStyle(.bordered)
+
+            Button("Present Settings Full Screen", action: onPresentSettings)
                 .buttonStyle(.bordered)
 
             Button("Sign Out", action: onSignOut)

--- a/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Modules/Home/HomeView.swift
+++ b/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Modules/Home/HomeView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct HomeView: View {
 
     var onSignOut: () -> Void = {}
+    var onShowSettings: () -> Void = {}
 
     var body: some View {
         VStack(spacing: 20) {
@@ -14,6 +15,9 @@ struct HomeView: View {
             Text("This starter flow demonstrates the signed-in state that teams can build on with product-specific screens.")
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
+
+            Button("Open Settings", action: onShowSettings)
+                .buttonStyle(.bordered)
 
             Button("Sign Out", action: onSignOut)
                 .buttonStyle(.borderedProminent)

--- a/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Modules/Landing/LandingView.swift
+++ b/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Modules/Landing/LandingView.swift
@@ -3,13 +3,9 @@ import SwiftUI
 @MainActor
 struct LandingView: View {
 
-    @StateObject private var viewModel: LandingViewModel
+    @StateObject private var viewModel: LandingViewModel = .init()
     @EnvironmentObject private var router: AppRouter
     @Environment(\.openURL) private var openURL
-
-    init() {
-        _viewModel = StateObject(wrappedValue: LandingViewModel())
-    }
 
     var body: some View {
         NavigationStack(path: $router.routes) {
@@ -48,9 +44,7 @@ struct LandingView: View {
     private func signOut() {
         Task {
             await viewModel.signOut()
-            router.popToRoot()
-            router.dismissCover()
-            router.dismissFullScreen()
+            router.reset()
         }
     }
 
@@ -76,8 +70,9 @@ struct LandingView: View {
 
     @ViewBuilder
     private func fullScreenDestination(for route: AppRoute) -> some View {
-        NavigationStack {
+        NavigationStack(path: $router.fullScreenRoutes) {
             destination(for: route)
+                .navigationDestination(for: AppRoute.self, destination: destination)
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
                         Button("Close", action: router.dismissFullScreen)

--- a/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Modules/Landing/LandingView.swift
+++ b/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Modules/Landing/LandingView.swift
@@ -4,21 +4,15 @@ import SwiftUI
 struct LandingView: View {
 
     @StateObject private var viewModel: LandingViewModel
-    @StateObject private var router: AppRouter
+    @EnvironmentObject private var router: AppRouter
     @Environment(\.openURL) private var openURL
 
     init() {
         _viewModel = StateObject(wrappedValue: LandingViewModel())
-        _router = StateObject(wrappedValue: AppRouter())
-    }
-
-    init(viewModel: LandingViewModel, router: AppRouter) {
-        _viewModel = StateObject(wrappedValue: viewModel)
-        _router = StateObject(wrappedValue: router)
     }
 
     var body: some View {
-        NavigationStack(path: $router.path) {
+        NavigationStack(path: $router.routes) {
             Group {
                 switch viewModel.state {
                 case .loading:
@@ -41,6 +35,7 @@ struct LandingView: View {
                 await viewModel.restoreSessionIfNeeded()
             }
         }
+        .sheet(item: $router.coverRoute, content: destination)
         .fullScreenCover(item: $router.fullScreenRoute, content: fullScreenDestination)
     }
 
@@ -54,6 +49,7 @@ struct LandingView: View {
         Task {
             await viewModel.signOut()
             router.popToRoot()
+            router.dismissCover()
             router.dismissFullScreen()
         }
     }

--- a/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Modules/Landing/LandingView.swift
+++ b/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Modules/Landing/LandingView.swift
@@ -4,28 +4,41 @@ import SwiftUI
 struct LandingView: View {
 
     @StateObject private var viewModel: LandingViewModel
+    @StateObject private var router: AppRouter
     @Environment(\.openURL) private var openURL
 
-    init(viewModel: LandingViewModel = LandingViewModel()) {
+    init() {
+        _viewModel = StateObject(wrappedValue: LandingViewModel())
+        _router = StateObject(wrappedValue: AppRouter())
+    }
+
+    init(viewModel: LandingViewModel, router: AppRouter) {
         _viewModel = StateObject(wrappedValue: viewModel)
+        _router = StateObject(wrappedValue: router)
     }
 
     var body: some View {
-        Group {
-            switch viewModel.state {
-            case .loading:
-                Color.clear
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            case .signedOut:
-                SignOutView(onContinue: continueWithDemoSession)
-            case .signedIn:
-                HomeView(onSignOut: signOut)
-            case .forceUpdateRequired:
-                ForceUpdateView(onUpdate: openAppStore)
+        NavigationStack(path: $router.path) {
+            Group {
+                switch viewModel.state {
+                case .loading:
+                    Color.clear
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                case .signedOut:
+                    SignOutView(onContinue: continueWithDemoSession)
+                case .signedIn:
+                    HomeView(
+                        onSignOut: signOut,
+                        onShowSettings: showSettings
+                    )
+                case .forceUpdateRequired:
+                    ForceUpdateView(onUpdate: openAppStore)
+                }
             }
-        }
-        .task {
-            await viewModel.restoreSessionIfNeeded()
+            .navigationDestination(for: AppRoute.self, destination: destination)
+            .task {
+                await viewModel.restoreSessionIfNeeded()
+            }
         }
     }
 
@@ -38,10 +51,23 @@ struct LandingView: View {
     private func signOut() {
         Task {
             await viewModel.signOut()
+            router.popToRoot()
         }
+    }
+
+    private func showSettings() {
+        router.push(.settings)
     }
 
     private func openAppStore() {
         openURL(Constants.appStoreURL)
+    }
+
+    @ViewBuilder
+    private func destination(for route: AppRoute) -> some View {
+        switch route {
+        case .settings:
+            SettingsView()
+        }
     }
 }

--- a/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Modules/Landing/LandingView.swift
+++ b/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Modules/Landing/LandingView.swift
@@ -29,7 +29,8 @@ struct LandingView: View {
                 case .signedIn:
                     HomeView(
                         onSignOut: signOut,
-                        onShowSettings: showSettings
+                        onShowSettings: showSettings,
+                        onPresentSettings: presentSettings
                     )
                 case .forceUpdateRequired:
                     ForceUpdateView(onUpdate: openAppStore)
@@ -40,6 +41,7 @@ struct LandingView: View {
                 await viewModel.restoreSessionIfNeeded()
             }
         }
+        .fullScreenCover(item: $router.fullScreenRoute, content: fullScreenDestination)
     }
 
     private func continueWithDemoSession() {
@@ -52,11 +54,16 @@ struct LandingView: View {
         Task {
             await viewModel.signOut()
             router.popToRoot()
+            router.dismissFullScreen()
         }
     }
 
     private func showSettings() {
         router.push(.settings)
+    }
+
+    private func presentSettings() {
+        router.presentFullScreen(.settings)
     }
 
     private func openAppStore() {
@@ -68,6 +75,18 @@ struct LandingView: View {
         switch route {
         case .settings:
             SettingsView()
+        }
+    }
+
+    @ViewBuilder
+    private func fullScreenDestination(for route: AppRoute) -> some View {
+        NavigationStack {
+            destination(for: route)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Close", action: router.dismissFullScreen)
+                    }
+                }
         }
     }
 }

--- a/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Modules/Settings/SettingsView.swift
+++ b/template/Tuist/Interfaces/SwiftUI/Sources/Presentation/Modules/Settings/SettingsView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct SettingsView: View {
+
+    var body: some View {
+        VStack(spacing: 20.0) {
+            Image(systemName: "gearshape")
+                .font(.system(size: 48))
+                .foregroundColor(.accentColor)
+            Text("Settings")
+                .font(.title2.bold())
+            Text("This placeholder route gives generated apps a native NavigationStack destination to extend.")
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .navigationTitle("Settings")
+    }
+}

--- a/template/{PROJECT_NAME}/Sources/Constants/Constants.swift
+++ b/template/{PROJECT_NAME}/Sources/Constants/Constants.swift
@@ -2,9 +2,11 @@
 //  Constants.swift
 //
 
+import Foundation
+
 enum Constants {
 
     enum API {}
 
-    static let appStoreURL = URL(string: <#"https://apps.apple.com/app/id000000000"#>)!
+    static let appStoreURL = URL(string: "https://apps.apple.com/app/id000000000")!
 }

--- a/template/{PROJECT_NAME}/Sources/Constants/Constants.swift
+++ b/template/{PROJECT_NAME}/Sources/Constants/Constants.swift
@@ -8,5 +8,5 @@ enum Constants {
 
     enum API {}
 
-    static let appStoreURL = URL(string: "https://apps.apple.com/app/id000000000")!
+    static let appStoreURL = URL(string: "https://apps.apple.com/app/id{APP_STORE_ID}")!
 }

--- a/template/{PROJECT_NAME}Tests/Sources/Specs/Presentation/Coordinators/AppRouterTests.swift
+++ b/template/{PROJECT_NAME}Tests/Sources/Specs/Presentation/Coordinators/AppRouterTests.swift
@@ -1,0 +1,38 @@
+import Testing
+
+@testable import {PROJECT_NAME}
+
+@MainActor
+@Suite("AppRouter")
+struct AppRouterTests {
+
+    @Test("pushes routes onto the navigation path")
+    func pushesRoutesOntoTheNavigationPath() {
+        let router = AppRouter()
+
+        router.push(.settings)
+
+        #expect(router.path == [.settings])
+    }
+
+    @Test("pops the last route from the navigation path")
+    func popsTheLastRouteFromTheNavigationPath() {
+        let router = AppRouter()
+        router.push(.settings)
+
+        router.pop()
+
+        #expect(router.path.isEmpty)
+    }
+
+    @Test("clears all routes from the navigation path")
+    func clearsAllRoutesFromTheNavigationPath() {
+        let router = AppRouter()
+        router.push(.settings)
+        router.push(.settings)
+
+        router.popToRoot()
+
+        #expect(router.path.isEmpty)
+    }
+}


### PR DESCRIPTION
- Close #710 

## What happened 👀

Added a native SwiftUI routing foundation to the template.

- Added `AppRoute` and `AppRouter` for route-based navigation.
- Wired `NavigationStack` into the signed-in starter flow.
- Added push/pop/root navigation helpers.
- Added full-screen route presentation with `fullScreenCover(item:)`.
- Added a Settings starter destination to demonstrate both push and full-screen routing.
- Replaced the dummy App Store URL with an `{APP_STORE_ID}` generation token.
- Removed the redundant `Foundation` import from `AppRoute`.

## Insight 📝

This gives generated apps a native routing foundation without introducing third-party navigation dependencies. It follows the same idea as CBTL’s route-driven navigation, while keeping the template lightweight with native `NavigationStack` and `fullScreenCover`.

Tested by generating a fresh project and running:

```bash
xcodebuild test \
  -project VerifyApp.xcodeproj \
  -scheme "VerifyApp Staging" \
  -configuration "Debug Staging"
  ```

### How to test

1. Generate a fresh project from the template.
2. Open the generated `VerifyApp.xcworkspace`.
3. Select the `VerifyApp Staging` scheme.
4. Run the app.
5. Continue with the demo session.
6. Tap `Open Settings` and verify it navigates to the Settings screen.
7. Tap `Sign Out` and verify the navigation path resets back to the signed-out flow.
8. Run the generated test scheme and confirm tests pass.


## Proof Of Work 📹

https://github.com/user-attachments/assets/943c1eb1-634f-4410-8956-2697da2554f4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Settings screen accessible from the home view
  * Settings can be opened in standard or full-screen presentation modes
  * App Store ID configuration option added to setup process

* **Tests**
  * Added test coverage for navigation functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->