### PR TITLE
[#709] Add deep-link parsing and route handling scaffold

### DIFF
--- a/.cicdtemplate/.github/actions/setup-ci-environment/action.yml
+++ b/.cicdtemplate/.github/actions/setup-ci-environment/action.yml
@@ -31,7 +31,7 @@ runs:
   using: composite
   steps:
     - name: Setup Ruby
-      uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # ruby/setup-ruby@v1.306.0
+      uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # ruby/setup-ruby@v1.310.0
       with:
         ruby-version: ${{ inputs.ruby-version }}
         bundler-cache: ${{ inputs.bundler-cache }}

--- a/.github/actions/setup-ci-environment/action.yml
+++ b/.github/actions/setup-ci-environment/action.yml
@@ -31,7 +31,7 @@ runs:
   using: composite
   steps:
     - name: Setup Ruby
-      uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # ruby/setup-ruby@v1.306.0
+      uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # ruby/setup-ruby@v1.310.0
       with:
         ruby-version: ${{ inputs.ruby-version }}
         bundler-cache: ${{ inputs.bundler-cache }}

--- a/template/{PROJECT_NAME}Tests/Sources/Specs/Presentation/Coordinators/AppRouterTests.swift
+++ b/template/{PROJECT_NAME}Tests/Sources/Specs/Presentation/Coordinators/AppRouterTests.swift
@@ -13,7 +13,7 @@ struct AppRouterTests {
 
         router.push(.settings)
 
-        #expect(router.path == [.settings])
+        #expect(router.routes == [.settings])
     }
 
     @Test("pops the last route from the navigation path")
@@ -23,7 +23,7 @@ struct AppRouterTests {
 
         router.pop()
 
-        #expect(router.path.isEmpty)
+        #expect(router.routes.isEmpty)
     }
 
     @Test("clears all routes from the navigation path")
@@ -34,7 +34,7 @@ struct AppRouterTests {
 
         router.popToRoot()
 
-        #expect(router.path.isEmpty)
+        #expect(router.routes.isEmpty)
     }
 
     @Test("opens pushed app links from URLs")
@@ -45,7 +45,7 @@ struct AppRouterTests {
         let handled = router.open(url)
 
         #expect(handled)
-        #expect(router.path == [.settings])
+        #expect(router.routes == [.settings])
         #expect(router.fullScreenRoute == nil)
     }
 
@@ -57,7 +57,7 @@ struct AppRouterTests {
         let handled = router.open(url)
 
         #expect(handled)
-        #expect(router.path.isEmpty)
+        #expect(router.routes.isEmpty)
         #expect(router.fullScreenRoute == .settings)
     }
 
@@ -69,7 +69,7 @@ struct AppRouterTests {
         let handled = router.open(url)
 
         #expect(!handled)
-        #expect(router.path.isEmpty)
+        #expect(router.routes.isEmpty)
         #expect(router.fullScreenRoute == nil)
     }
 }


### PR DESCRIPTION
- Close #709

## What happened 👀

Added a SwiftUI deep-link scaffold to the generated app template:

- Introduced `AppLink` to parse incoming URLs into app routes.
- Added `AppRouter.open(_:)` handling for pushed and full-screen routes.
- Wired `LandingView` to receive links from `onOpenURL` and universal-link user activities.
- Registered the generated bundle identifier as the app URL scheme in `Info.plist`.
- Added example settings routes and tests for link parsing and route handling.

## Insight 📝

The scaffold keeps URL parsing isolated from SwiftUI views while reusing the template's existing `AppRouter` navigation state. The example routes are intentionally small so generated apps can extend `AppLink` and `AppRoute` without replacing the routing foundation.

Verification performed locally:

- Generated a fresh app from the template in `/tmp`.
- Ran `xcodebuild -list` against the generated workspace.
- Ran `xcodebuild test` on the generated `DeepLinkDemo Staging` scheme; all tests passed, including `AppLink` and `AppRouter`.

Note: `swiftlint` is currently blocked locally by a SwiftLint configuration read error: `Could not read configuration: file Configuration.swift, line 289`.

## Proof Of Work 📹

The generated project test run succeeded locally with the new deep-link parser and router test suites passing.