### PR TITLE
[Bug] Remove the unnecessary trigger of add device workflow

### DIFF
--- a/.cicdtemplate/.github/workflows/add_device_profile.yml
+++ b/.cicdtemplate/.github/workflows/add_device_profile.yml
@@ -8,7 +8,6 @@ name: Test Add device and regenerate profiles with fastlane match
 ### ISSUER_ID
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       devices:


### PR DESCRIPTION
## What happened 👀

- Remove on `pull_request` trigger of `add_device_profile.yml`

## Insight 📝

In the generated project from the iOS Templates, each time a developer opens a PR, it will trigger the `add_device_profile` workflow, which should be triggered manually.

<img width="2005" height="438" alt="Screenshot 2026-05-06 at 15 20 32" src="https://github.com/user-attachments/assets/bee20cc5-2b12-495c-81db-e71fa9b4f411" />

<img width="1855" height="656" alt="Screenshot 2026-05-06 at 15 23 36" src="https://github.com/user-attachments/assets/d940b989-2b81-49ca-a149-c6b62bc8db46" />


## Proof Of Work 📹

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development workflow configuration.

*No user-facing changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->