### PR TITLE
[#716] Resolve project generation and app build warnings

### DIFF
--- a/scripts/iOSTemplateMaker/Sources/iOSTemplateMaker/SetUpiOSProject.swift
+++ b/scripts/iOSTemplateMaker/Sources/iOSTemplateMaker/SetUpiOSProject.swift
@@ -93,6 +93,10 @@ class SetUpIOSProject {
                 try promoteTemplateToRoot()
             }
 
+            try step(title: "Remove contributor-only agent files") {
+                try removeContributorOnlyAgentFiles()
+            }
+
             try step(title: "Setup CI/CD") {
                 try setUpCICD()
             }
@@ -263,6 +267,11 @@ class SetUpIOSProject {
             try fileManager.removeItems(in: name)
         }
         try safeShell("git reset")
+    }
+
+    private func removeContributorOnlyAgentFiles() throws {
+        try fileManager.removeItems(in: "AGENTS.md")
+        try fileManager.removeItems(in: "CLAUDE.md")
     }
 
     private func setUpCICD() throws {

--- a/template/Modules/Analytics/Configurations/Plists/Info.plist
+++ b/template/Modules/Analytics/Configurations/Plists/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/template/Modules/Analytics/Tests/Configurations/Plists/Info.plist
+++ b/template/Modules/Analytics/Tests/Configurations/Plists/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/template/Modules/Data/Configurations/Plists/Info.plist
+++ b/template/Modules/Data/Configurations/Plists/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/template/Modules/Data/Tests/Configurations/Plists/Info.plist
+++ b/template/Modules/Data/Tests/Configurations/Plists/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/template/Modules/Domain/Configurations/Plists/Info.plist
+++ b/template/Modules/Domain/Configurations/Plists/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/template/Modules/Domain/Tests/Configurations/Plists/Info.plist
+++ b/template/Modules/Domain/Tests/Configurations/Plists/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/template/Modules/Model/Configurations/Plists/Info.plist
+++ b/template/Modules/Model/Configurations/Plists/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/template/Modules/Model/Tests/Configurations/Plists/Info.plist
+++ b/template/Modules/Model/Tests/Configurations/Plists/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/template/Package.swift
+++ b/template/Package.swift
@@ -3,13 +3,9 @@
 
 #if TUIST
     import struct ProjectDescription.PackageSettings
-    import enum ProjectDescription.Product
 
     let packageSettings = PackageSettings(
-        productTypes: [
-            "Alamofire": .framework,
-            "FactoryKit": .framework
-        ]
+        productTypes: [:]
     )
 #endif
 

--- a/template/Package.swift
+++ b/template/Package.swift
@@ -3,9 +3,13 @@
 
 #if TUIST
     import struct ProjectDescription.PackageSettings
+    import enum ProjectDescription.Product
 
     let packageSettings = PackageSettings(
-        productTypes: [:]
+        productTypes: [
+            "Alamofire": .framework,
+            "FactoryKit": .framework
+        ]
     )
 #endif
 

--- a/template/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/template/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -47,8 +47,16 @@ public enum Module: CaseIterable {
         []
     }
 
+    public var infoPlist: ProjectDescription.InfoPlist {
+        .file(path: "\(frameworkPath)/\(Constant.plistsPath)/Info.plist")
+    }
+
     public var testsSources: ProjectDescription.SourceFilesList {
         ["\(frameworkPath)/\(Constant.testsPath)/**"]
+    }
+
+    public var testsInfoPlist: ProjectDescription.InfoPlist {
+        .file(path: "\(frameworkPath)/\(Constant.testsPath)/\(Constant.plistsPath)/Info.plist")
     }
 
     public var testsResources: ProjectDescription.ResourceFileElements {

--- a/template/Tuist/ProjectDescriptionHelpers/Target+Initializing.swift
+++ b/template/Tuist/ProjectDescriptionHelpers/Target+Initializing.swift
@@ -36,8 +36,13 @@ extension Target {
                 .target(name: Module.data.name),
                 .target(name: Module.domain.name),
                 .target(name: Module.model.name),
+                // Backend
+                .package(product: "Alamofire"),
+                .package(product: "JSONAPIMapper"),
                 // UI
                 .package(product: "Kingfisher"),
+                // Storage
+                .package(product: "KeychainAccess"),
                 // Tools
                 .package(product: "FirebaseCrashlytics"), // From firebase-ios-sdk
                 .package(product: "NimbleExtension"),

--- a/template/Tuist/ProjectDescriptionHelpers/Target+Initializing.swift
+++ b/template/Tuist/ProjectDescriptionHelpers/Target+Initializing.swift
@@ -36,13 +36,8 @@ extension Target {
                 .target(name: Module.data.name),
                 .target(name: Module.domain.name),
                 .target(name: Module.model.name),
-                // Backend
-                .package(product: "Alamofire"),
-                .package(product: "JSONAPIMapper"),
                 // UI
                 .package(product: "Kingfisher"),
-                // Storage
-                .package(product: "KeychainAccess"),
                 // Tools
                 .package(product: "FirebaseCrashlytics"), // From firebase-ios-sdk
                 .package(product: "NimbleExtension"),
@@ -55,7 +50,11 @@ extension Target {
                     "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                     // ALWAYS_SEARCH_USER_PATHS: Disables deprecated traditional headermap style.
                     // Set to NO to use modern separate headermaps and eliminate Xcode warnings.
-                    "ALWAYS_SEARCH_USER_PATHS": "NO"
+                    "ALWAYS_SEARCH_USER_PATHS": "NO",
+                    // Keep Xcode from attempting to strip already signed embedded local frameworks.
+                    "COPY_PHASE_STRIP": "NO",
+                    "STRIP_INSTALLED_PRODUCT": "NO",
+                    "DEPLOYMENT_POSTPROCESSING": "NO"
                 ]
             )
         )
@@ -68,6 +67,7 @@ extension Target {
             product: .framework,
             bundleId: module.bundleId(mainBundleId: bundleId),
             deploymentTargets: .iOS("{TARGET_VERSION}"),
+            infoPlist: module.infoPlist,
             sources: module.sources,
             resources: module.resources,
             dependencies: module.dependencies,
@@ -78,7 +78,11 @@ extension Target {
                     "SKIP_INSTALL": "YES",
                     // ALWAYS_SEARCH_USER_PATHS: Disables deprecated traditional headermap style.
                     // Set to NO to use modern separate headermaps and eliminate Xcode warnings.
-                    "ALWAYS_SEARCH_USER_PATHS": "NO"
+                    "ALWAYS_SEARCH_USER_PATHS": "NO",
+                    // Keep Xcode from attempting to strip already signed local frameworks.
+                    "COPY_PHASE_STRIP": "NO",
+                    "STRIP_INSTALLED_PRODUCT": "NO",
+                    "DEPLOYMENT_POSTPROCESSING": "NO"
                 ]
             )
         )
@@ -88,6 +92,7 @@ extension Target {
             destinations: .iOS,
             product: .unitTests,
             bundleId: module.testBundleId(mainBundleId: bundleId),
+            infoPlist: module.testsInfoPlist,
             sources: module.testsSources,
             resources: module.testsResources,
             dependencies: moduleTestDependencies(for: module)


### PR DESCRIPTION
- Close #716 

## What happened 👀
 - Add explicit `Info.plist` files for module framework targets.
 - Add explicit `Info.plist` files for module test targets.
 - Add strip-related build settings to reduce signed framework stripping warnings.
 - Remove agent docs from generated projects.

## Insight 📝
<img width="1898" height="1123" alt="Screenshot 2026-05-07 at 11 12 39" src="https://github.com/user-attachments/assets/84d0aeec-06bc-4bcf-ac21-5fe6ba1ff906" />

<img width="1898" height="1123" alt="Screenshot 2026-05-07 at 11 12 44" src="https://github.com/user-attachments/assets/6672331f-fc47-405b-ac45-70fa7969303e" />

## Proof Of Work 📹
<img width="2030" height="1227" alt="Screenshot 2026-05-07 at 11 10 03" src="https://github.com/user-attachments/assets/fd5287a0-3c87-448b-97b8-3b9159c6a372" />

<img width="4060" height="2454" alt="Screenshot 2026-05-07 at 11 10 31" src="https://github.com/user-attachments/assets/06d959be-8ad8-4cf3-8aa3-c82ac1eff5c5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced iOS project generation to remove contributor-specific files from generated projects, resulting in cleaner deliverables.

* **Refactor**
  * Improved module and framework configuration management for better build organization.
  * Optimized build settings for app and framework targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->