### PR TITLE
[#723] Automate GitHub Release creation process and tagging

### DIFF
--- a/.cicdtemplate/.github/workflows/configs/changelog-config.json
+++ b/.cicdtemplate/.github/workflows/configs/changelog-config.json
@@ -31,5 +31,5 @@
       ]
     }
   ],
-  "max_pull_requests": 200
+  "pr_template": "- #{{TITLE}} (by @#{{ASSIGNEES}} in [##{{NUMBER}}](#{{URL}}))"
 }

--- a/.cicdtemplate/.github/workflows/create_release_pull_request.yml
+++ b/.cicdtemplate/.github/workflows/create_release_pull_request.yml
@@ -11,21 +11,27 @@ jobs:
     name: Create Release Pull Request
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Get release version
+        id: extract_version
         run: |
           filename=$(find . -maxdepth 1 -name "*.xcodeproj" -exec basename {} .xcodeproj \; | head -n 1)
-          release_version=$(sed -n 's/.*MARKETING_VERSION *= *\([^;]*\);.*/\1/p' "$filename.xcodeproj/project.pbxproj" | head -n 1 | sed 's/^[^=]*=\s*//' | tr -d ' ')
-          echo $release_version
-          echo "RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
+          version=$(sed -n 's/.*MARKETING_VERSION *= *\([^;]*\);.*/\1/p' "$filename.xcodeproj/project.pbxproj" | head -n 1 | sed 's/^[^=]*=\s*//' | tr -d ' ')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Build version: $version"
 
       - uses: nimblehq/github-actions-workflows/create_release_pull_request@d2f913f1faba9dd814eb0cab86147d2bab6e0e34 # nimblehq/github-actions-workflows/create_release_pull_request@v0.1.10
         with:
-          release_version: ${{ env.RELEASE_VERSION }}
+          release_version: "${{ steps.extract_version.outputs.version }}"
           changelog_configuration: ".github/workflows/configs/changelog-config.json"
-          assignee: bot-nimble
+          base_branch: main
+          assignee: ${{ github.actor }}

--- a/.cicdtemplate/.github/workflows/tag_release.yml
+++ b/.cicdtemplate/.github/workflows/tag_release.yml
@@ -1,0 +1,68 @@
+name: Tag the new Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+permissions:
+  actions: write
+  contents: write
+
+jobs:
+  tag_and_release:
+    name: Tag and release
+    if: |
+      github.event.pull_request.merged == true
+      && contains(github.event.pull_request.labels.*.name, 'type : release')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Extract release version from head branch
+        id: extract_version
+        shell: bash
+        run: |
+          head_ref="${{ github.event.pull_request.head.ref }}"
+          if [[ ! "$head_ref" =~ ^release/([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "Head ref '$head_ref' does not match release/X.Y.Z pattern"
+            exit 1
+          fi
+          version="${BASH_REMATCH[1]}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Extracted version: $version"
+
+      - name: Checkout main at merge commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+
+      - name: Ensure tag does not already exist
+        shell: bash
+        run: |
+          tag="${{ steps.extract_version.outputs.version }}"
+          if git rev-parse "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "Tag $tag already exists — refusing to overwrite"
+            exit 1
+          fi
+
+      - name: Create and push tag
+        shell: bash
+        run: |
+          tag="${{ steps.extract_version.outputs.version }}"
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git tag -a "$tag" -m "Release $tag"
+          git push origin "$tag"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          tag="${{ steps.extract_version.outputs.version }}"
+          gh release create "$tag" \
+            --target "${{ github.event.pull_request.merge_commit_sha }}" \
+            --title "$tag" \
+            --generate-notes


### PR DESCRIPTION
- Close #723

## What happened 👀

- Change the fetch depth in create release pr workflow to 0 -> need to get all commit history to generate change log.
- Add permission to read milestones 
- Include the assignee to the PR in the release change log
- Create `tag_release.yml` workflow to automatically create new release and tag release version after merging release to `main`

## Insight 📝

Automate create release and tagging a version on GitHub

## Proof Of Work 📹

<img width="647" height="329" alt="Screenshot 2026-05-22 at 15 21 45" src="https://github.com/user-attachments/assets/24f40384-71f2-4b0a-b85e-0eb4212a5483" />

Run: 
- https://github.com/phongvhd93/ios-template-playground/actions/runs/26275124799

**Note: You can check the release format and tag from my playground repo. Better to try it yourself.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated release tagging and GitHub Release generation now triggers automatically when pull requests containing release-type labels are merged to the main branch.

* **Chores**
  * Improved release workflow with enhanced permission controls for repository contents and pull requests, plus full repository history access.
  * Updated pull request template configuration for consistent release note formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nimblehq/ios-templates/pull/724?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->